### PR TITLE
Keybinding bugs

### DIFF
--- a/ufork-wasm/www/index.html
+++ b/ufork-wasm/www/index.html
@@ -82,7 +82,7 @@ table {
   <div id="loader">
     <form id="boot-form">
       <input id="boot-url" type="text" size="42" value="../lib/test.asm" />
-      <input type="submit" value="Boot" />
+      <input id="boot" type="submit" value="Boot" />
     </form>
   </div>
   <pre id="rom" class="panel" title="ROM Image"></pre>

--- a/ufork-wasm/www/index.js
+++ b/ufork-wasm/www/index.js
@@ -1104,6 +1104,7 @@ function boot(module_specifier) {
 
 const $gcButton = document.getElementById("gc-btn");
 $gcButton.onclick = gcHost;
+$gcButton.title = "Run garbage collection (g)";
 
 const $nextButton = document.getElementById("next-step");
 $nextButton.onclick = nextStep;
@@ -1131,15 +1132,25 @@ const pauseAction = () => {
     drawHost();
 }
 
-const $bootForm = document.getElementById("boot-form");
 const $bootInput = document.getElementById("boot-url");
+const $bootForm = document.getElementById("boot-form");
 $bootForm.onsubmit = function (event) {
     boot($bootInput.value);
     event.preventDefault();
 };
+const $bootButton = document.getElementById("boot");
+$bootButton.title = "Boot from module (b)";
 
 // Keybindings
 document.onkeydown = function (event) {
+    if (
+        event.metaKey
+        || event.ctrlKey
+        || event.altKey
+        || document.activeElement !== document.body // focused <input> etc
+    ) {
+        return;
+    }
     if (event.key === "c") {
         if (paused) {
             playAction();
@@ -1150,6 +1161,10 @@ document.onkeydown = function (event) {
         singleStep();
     } else if (event.key === "n" && !$nextButton.disabled) {
         nextStep();
+    } else if (event.key === "b") {
+        boot($bootInput.value);
+    } else if (event.key === "g") {
+        gcHost();
     }
 };
 


### PR DESCRIPTION
Previously, pressing "ctrl+c" would continue execution (c) as a side effect of copying selected text to the clipboard.  Now, key events involving meta, ctrl or alt are ignored.

Also, key events originating from form elements are ignored (for example, typing ".asm" into the boot input would step to the next instruction).

In addition, two new keybindings are added, g (for GC) and b (for boot).