### PR TITLE
Standardize 'beh' export

### DIFF
--- a/ufork-wasm/lib/cell.asm
+++ b/ufork-wasm/lib/cell.asm
@@ -57,9 +57,9 @@ CAS:                    ; <- (tag cust old new)
     state 1             ; old value
     cmp eq              ; old==value
     if_not read         ; --
-    msg 4               ; new
-    my beh              ; new beh
-    beh 1               ; --
+    msg -3              ; (new)
+    my beh              ; (new) beh
+    beh -1              ; --
     ref read
 
 ; unit test suite

--- a/ufork-wasm/lib/cell.asm
+++ b/ufork-wasm/lib/cell.asm
@@ -182,9 +182,9 @@ test_overlap:           ; () <- ()
 cell_set_bit:           ; (cell) <- (cust bit)
     msg 1               ; cust
     state 1             ; cust cell
-    msg 2               ; cell cust bit
-    push #?             ; cell cust bit old=#?
-    push cell_try_bit   ; cell cust bit old cell_try_bit
+    msg 2               ; cust cell bit
+    push #?             ; cust cell bit old=#?
+    push cell_try_bit   ; cust cell bit old cell_try_bit
     new 4               ; cust'=cell_try_bit.(old bit cell cust)
     push read_tag       ; cust' tag=read_tag
     state 1             ; cust' tag cell

--- a/ufork-wasm/lib/cell.asm
+++ b/ufork-wasm/lib/cell.asm
@@ -27,7 +27,8 @@ CAS_tag:
 ;;      END
 ;;  ]
 ;;  CREATE cell WITH cell_beh(0)
-beh:                    ; (value) <- (tag cust . req)
+beh:
+cell_beh:               ; (value) <- (tag cust . req)
     msg 1               ; tag
     eq read_tag         ; tag==read
     if read             ; --
@@ -83,7 +84,7 @@ boot:
 
 test_read_beh:
     push 5              ; 5
-    push beh            ; 5 beh
+    push cell_beh       ; 5 cell_beh
     new 1               ; cell(5)
     push 5              ; cell(5) 5
     push check_read_beh ; cell(5) 5 check_read_beh
@@ -97,7 +98,7 @@ test_write_beh:
     new -1              ; 5 check_read(5)
     push write_tag      ; 5 check_read(5) #write
     push 4              ; 5 check_read(5) #write 4
-    push beh            ; 5 check_read(5) #write 4 beh
+    push cell_beh       ; 5 check_read(5) #write 4 cell_beh
     new 1               ; 5 check_read(5) #write cell(4)
     send 3              ; --
     ref std.commit
@@ -116,7 +117,7 @@ test_miss_beh:
 
 test_CAS:               ; new old expect
     push 4              ; new old expect 4
-    push beh            ; new old expect 4 beh
+    push cell_beh       ; new old expect 4 cell_beh
     new 1               ; new old expect cell(4)
     roll 2              ; new old cell(4) expect
     pick 2              ; new old cell(4) expect cell(4)
@@ -154,8 +155,8 @@ assert_eq_beh:          ; expect <- value
 
 test_overlap:           ; () <- ()
     push 4              ; 4
-    push beh            ; 4 beh
-    new 1               ; cell=beh.(4)
+    push cell_beh       ; 4 cell_beh
+    new 1               ; cell=cell_beh.(4)
     dup 1               ; cell cell
     push cell_set_bit   ; cell cell cell_set_bit
     new 1               ; cell svc1=cell_set_bit.(cell)
@@ -167,7 +168,7 @@ test_overlap:           ; () <- ()
     push cell_verify    ; svc1 svc2 7 cell cell_verify
     new 2               ; t_svc=svc1 h_svc=svc2 cust=cell_verify(cell 7)
 
-    push fork.fork_beh  ; t_svc h_svc cust fork_beh
+    push fork.beh       ; t_svc h_svc cust fork_beh
     new 3               ; fork.(cust h_svc t_svc)
     push #nil           ; fork ()
     push 2              ; fork () 2

--- a/ufork-wasm/lib/fork.asm
+++ b/ufork-wasm/lib/fork.asm
@@ -13,6 +13,7 @@
 ;;      SEND (h_tag, h_req) TO h_svc
 ;;      BECOME join_beh(cust, h_tag, t_tag)
 ;;  ]
+beh:
 fork_beh:               ; (cust h_svc t_svc) <- (h_req . t_req)
     my self             ; SELF
     push lib.tag_beh    ; SELF tag_beh
@@ -131,5 +132,5 @@ verify:                 ; () <- (42 . -42)
     ref std.commit
 
 .export
-    fork_beh
+    beh
     boot

--- a/ufork-wasm/lib/future.asm
+++ b/ufork-wasm/lib/future.asm
@@ -15,6 +15,7 @@
 ;;                      (BECOME (wait-beh (list arg) rcap wcap)))
 ;;                  ((eq? tag wcap)
 ;;                      (BECOME (value-beh rcap arg))) ))))
+beh:
 future_beh:             ; (rcap wcap) <- (tag . arg)
     msg 1               ; tag
     state 1             ; tag rcap
@@ -137,5 +138,5 @@ boot:                   ; () <- {caps}
     ref std.commit
 
 .export
-    future_beh
+    beh
     boot

--- a/ufork-wasm/lib/serial.asm
+++ b/ufork-wasm/lib/serial.asm
@@ -19,6 +19,7 @@ once_tag_beh:
 ;;              (define tag (CREATE (once-tag-beh SELF)))
 ;;              (SEND svc (tag . req))
 ;;              (BECOME (busy-beh (deque-new) tag cust svc)) )))
+beh:
 serial_beh:             ; (svc) <- (cust . req)
     my self             ; SELF
     push once_tag_beh   ; SELF once-tag-beh
@@ -207,5 +208,5 @@ boot:                   ; () <- {caps}
     ref std.commit
 
 .export
-    serial_beh
+    beh
     boot


### PR DESCRIPTION
It is desirable to refer to the main behavior locally like

    push cell_beh   ; e.g. in cell.asm

but refer to the behavior externally like

    push cell.beh   ; e.g. in serial.asm

rather than

    push cell.cell_beh

which is repetitive and, worse, implies that the cell.asm module exports
behaviors besides 'cell_beh'.

I propose that we alias the main behavior in a module as 'beh' and export just
the alias.