### PR TITLE
generate TLS certificates

### DIFF
--- a/ufork-wasm/awp.md
+++ b/ufork-wasm/awp.md
@@ -117,13 +117,11 @@ The `listen` factory takes the following parameters:
 
 It returns a requestor that takes a `listen_callback`:
 
-    listen_callback(result, reason)
-        If successful, the 'result' parameter is an object like {stop, info}.
-        Otherwise 'result' is undefined and 'reason' provides an explanation.
+    listen_callback(stop, reason)
 
-        The "stop" property is a function that stops listening.
-        The "info" property provides additional information, such as the
-        resolved address.
+        If successful, the 'stop' parameter is a function that stops listening
+        when called. Otherwise 'stop' is undefined and 'reason' provides an
+        explanation.
 
 The requestor may return a `cancel` function that cancels the listen attempt.
 
@@ -244,9 +242,8 @@ greeter is available, the request fails.
 
     (#listen cancel_customer callback store greeter) -> awp_device
 
-Listens for introduction requests, producing a value like `(stop . info)` on
-success. The `info` value is transport-dependent. The `stop` capability stops
-the listener.
+Listens for introduction requests, producing a `stop` capability on success that
+can be used to stop listening:
 
     -> stop
 

--- a/ufork-wasm/gm/run.js
+++ b/ufork-wasm/gm/run.js
@@ -2,7 +2,7 @@
 
 /*jslint node, long */
 
-import {webcrypto} from "node:crypto";
+import crypto from "node:crypto";
 import instantiate_core from "../www/ufork.js";
 import debug_device from "../www/devices/debug_device.js";
 import awp_device from "../www/devices/awp_device.js";
@@ -11,45 +11,49 @@ import node_tls_transport from "../www/devices/node_tls_transport.js";
 const transport = node_tls_transport();
 const bob_address = {host: "localhost", port: 4001};
 const carol_address = {host: "localhost", port: 4002};
-const alice_cert = "-----BEGIN CERTIFICATE-----\nMIIBlzCB+QIJAKdXgQPMUTS5MAoGCCqGSM49BAMCMBAxDjAMBgNVBAMMBXVmb3JrMB4XDTIzMDYxNTAxMzEzOVoXDTIzMDcxNTAxMzEzOVowEDEOMAwGA1UEAwwFdWZvcmswgZswEAYHKoZIzj0CAQYFK4EEACMDgYYABABAO06FL/42NDAfp8YFC7KZs0ArEM6ocluQe+u7IPkis0kl1O8/6B3FmnR7GfTXQubdc0EFcueKjMyR8D/JY9wDhQAqUjXzVIePzADbfo8vUjrPQ9TBzl+T85XjeBKbDiKZQb8QxeyYlqO246/XksSZJl0vn91gXTbBAR1ZgYeTPd44ljAKBggqhkjOPQQDAgOBjAAwgYgCQgHvlQMSDNJpJTT9/0PsiQIkI2Ui4fJpBDJr1fzYQgVMmnqx5Uvng9DHr1+AU7DDU9+2X1V2OaRsgJAymv1om/vz5wJCAKoHuyWggL9LGkTPUiUqm3dA/JS5dOnKGmdDEqMbEeiofFpt/joV8sdTAw2uigkliw+9vfLMLkJyr2sW3fjiWTBo\n-----END CERTIFICATE-----";
-const alice_key = "-----BEGIN EC PRIVATE KEY-----\nMIHbAgEBBEFCXfqEm5o/WBTMWkHpyz4f+6xqJv7GF+AajgBkyRYMncp6lZInDOKk2aC6oNerZdcDTXnqZ/TKZl1z9OSPkwIsd6AHBgUrgQQAI6GBiQOBhgAEAEA7ToUv/jY0MB+nxgULspmzQCsQzqhyW5B767sg+SKzSSXU7z/oHcWadHsZ9NdC5t1zQQVy54qMzJHwP8lj3AOFACpSNfNUh4/MANt+jy9SOs9D1MHOX5PzleN4EpsOIplBvxDF7JiWo7bjr9eSxJkmXS+f3WBdNsEBHVmBh5M93jiW\n-----END EC PRIVATE KEY-----";
-const bob_cert = "-----BEGIN CERTIFICATE-----\nMIIBlzCB+QIJAMfPBllRxdANMAoGCCqGSM49BAMCMBAxDjAMBgNVBAMMBXVmb3JrMB4XDTIzMDYxNTAxMjYzM1oXDTIzMDcxNTAxMjYzM1owEDEOMAwGA1UEAwwFdWZvcmswgZswEAYHKoZIzj0CAQYFK4EEACMDgYYABACCfQXDKhuHQUQIzpU2HsgZK1n5eziSRHu+/tl67Pso6mSNSiWdhDwObikaOplnFO10IdGaoflbWn+qV3tSXTMYTABd6K9nN7ki/8/Ppoz0It9cqLn60u3RHHPpgrcAEFHpNA/LqItP/t55f6XPArvnt0xIfxjaI4gdwb2uUfnzITruSTAKBggqhkjOPQQDAgOBjAAwgYgCQgEqJCq5FDRvWYC8dMhzzcObvMJJ4FriVRlaEPH94FV1eZIvWLhpSkpzh02+KfiwclO0YJVzGAh7tFEBFZ1U+0A1BAJCAZ9ugBLIqRZXOR+ndUIAs917W9Dw+imQkbiHlKdU8rhGZgA7r29VAfx3A7l+1BmXUrvQRBuU6BoBMxW2BRTQ4wQ1\n-----END CERTIFICATE-----";
-const bob_key = "-----BEGIN EC PRIVATE KEY-----\nMIHbAgEBBEE8BpKem+dZRCbbI33kCwXCADskDId/WhAE7RFRttOnV0m2kxwkad/bDpd20I7dNdUSD5VRk0GsVQacoHtMxdsBlKAHBgUrgQQAI6GBiQOBhgAEAIJ9BcMqG4dBRAjOlTYeyBkrWfl7OJJEe77+2Xrs+yjqZI1KJZ2EPA5uKRo6mWcU7XQh0Zqh+Vtaf6pXe1JdMxhMAF3or2c3uSL/z8+mjPQi31youfrS7dEcc+mCtwAQUek0D8uoi0/+3nl/pc8Cu+e3TEh/GNojiB3Bva5R+fMhOu5J\n-----END EC PRIVATE KEY-----";
-const carol_cert = "-----BEGIN CERTIFICATE-----\nMIIBlzCB+QIJAKXgK2B3FNUbMAoGCCqGSM49BAMCMBAxDjAMBgNVBAMMBXVmb3JrMB4XDTIzMDYxNTAxMDExNFoXDTIzMDcxNTAxMDExNFowEDEOMAwGA1UEAwwFdWZvcmswgZswEAYHKoZIzj0CAQYFK4EEACMDgYYABAD/K8/8lKykhrjH8R6VlEKg2leMjkxBZe/6mzzsymuvD9bn4kDsIj6wjRRaiErlcYisw8ZiJOKlGGAjrIU1ISzitACOZDZ50Xj63N6LQ8rpkoKmbDhWuoD1v0uClMr7IhjG26nsPiHjhJ5UB4FIY/gVu4cci/tkCPgNu4KQUnyYU1SgXTAKBggqhkjOPQQDAgOBjAAwgYgCQgHcMCYkwLybOyQ7ErtE5ucY2CjHStIJWOhgHD/RYrTX4uoXOVl2ISb7F4COQ8Xm1vepNvlWA9PfTbHjXopB6f2D+wJCAZ/Vzcnjsf8wSpm8x34uNYlvo0K+LZNFlQ7EuImKk33QbVR30KAS3y+Ok8yNAucg3Zh1243k09iCFLXmyclcUZgk\n-----END CERTIFICATE-----";
-const carol_key = "-----BEGIN EC PRIVATE KEY-----\nMIHbAgEBBEErmNL2SxVE8Mi13BclwRfR1j/OWNDrt8fMXT8VTzVwfhFBV1XmIXRCB+s4VkQEQWfi69xgA1J1nz/4eWAOuieFoqAHBgUrgQQAI6GBiQOBhgAEAP8rz/yUrKSGuMfxHpWUQqDaV4yOTEFl7/qbPOzKa68P1ufiQOwiPrCNFFqISuVxiKzDxmIk4qUYYCOshTUhLOK0AI5kNnnRePrc3otDyumSgqZsOFa6gPW/S4KUyvsiGMbbqew+IeOEnlQHgUhj+BW7hxyL+2QI+A27gpBSfJhTVKBd\n-----END EC PRIVATE KEY-----";
-const dana_cert = "-----BEGIN CERTIFICATE-----\nMIIBlzCB+QIJAPLWr8RQKQBGMAoGCCqGSM49BAMCMBAxDjAMBgNVBAMMBXVmb3JrMB4XDTIzMDYxNTAxMzIwOVoXDTIzMDcxNTAxMzIwOVowEDEOMAwGA1UEAwwFdWZvcmswgZswEAYHKoZIzj0CAQYFK4EEACMDgYYABAAGfk1CmCfXy63+jOA/S2HgjWiILtTI5R14khfnxzo17+CxdmgiVd3nBtlw8JSP7epZN79Bb+v8sstpBpXPsdJAsQCLEczVVhPA4s32qXM5cPqeua2hOeJAIWs2T2gmJY5NmMsWEksyWKAJRqyks/T37rrCbJXla6r5EtWkDi+zFwVFUDAKBggqhkjOPQQDAgOBjAAwgYgCQgFQMwTdOqg3jFTKcnKagjd6YAFVFsFPEVaZWkLFbpzb7PGOGu8mpB3MGp5381jFjIUK3TEZpvuH54AfWaajtBKCqwJCAdloA77rsAnqlFsz0buZ4nGXSu8eNokvztuDQcFoiCeNtke4NVSdbdclj3xa0LMbLj7ts1sDI/R4t2QT1T2XgFvm\n-----END CERTIFICATE-----";
-const dana_key = "-----BEGIN EC PRIVATE KEY-----\nMIHbAgEBBEGdbH0ztVSCg/8231sFBl07WGdEt26fuMauXcU3Gp24luV+MwaegTDYG7M9CG7LrMvuZipiQPVOgai40b41RzNOjKAHBgUrgQQAI6GBiQOBhgAEAAZ+TUKYJ9fLrf6M4D9LYeCNaIgu1MjlHXiSF+fHOjXv4LF2aCJV3ecG2XDwlI/t6lk3v0Fv6/yyy2kGlc+x0kCxAIsRzNVWE8Dizfapczlw+p65raE54kAhazZPaCYljk2YyxYSSzJYoAlGrKSz9PfuusJsleVrqvkS1aQOL7MXBUVQ\n-----END EC PRIVATE KEY-----";
+const alice_identity = crypto.createPrivateKey(`-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIBe3+oTrkYxovSHOmjhrbCHQmv5h1qFOipXXlG5swzEW
+-----END PRIVATE KEY-----`);
+const bob_identity = crypto.createPrivateKey(`-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIN6VM5RlTK8uRHP2ZEmJCfUsXnGBF4RBF1jLrdWpt+4H
+-----END PRIVATE KEY-----`);
+const carol_identity = crypto.createPrivateKey(`-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIBsN+u2pWW58jJteLzvYpNy+cpsKzByJWBS21sCyMkTd
+-----END PRIVATE KEY-----`);
+const dana_identity = crypto.createPrivateKey(`-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEINTatAbnOgcatVHstpOCLskSHU5nogWEpe7fiDQUMZIF
+-----END PRIVATE KEY-----`);
 const acquaintances = [
     {
-        name: transport.extract_public_key(bob_cert),
+        name: transport.get_name(bob_identity),
         address: bob_address
     },
     {
-        name: transport.extract_public_key(carol_cert),
+        name: transport.get_name(carol_identity),
         address: carol_address
     }
 ];
 const stores = {
     alice: {
-        identity: {cert: alice_cert, key: alice_key},
-        name: transport.extract_public_key(alice_cert),
+        identity: alice_identity,
+        name: transport.get_name(alice_identity),
         acquaintances
     },
     bob: {
-        identity: {cert: bob_cert, key: bob_key},
-        name: transport.extract_public_key(bob_cert),
+        identity: bob_identity,
+        name: transport.get_name(bob_identity),
         address: bob_address,
         bind_info: bob_address
     },
     carol: {
-        identity: {cert: carol_cert, key: carol_key},
-        name: transport.extract_public_key(carol_cert),
+        identity: carol_identity,
+        name: transport.get_name(carol_identity),
         address: carol_address,
         bind_info: carol_address
     },
     dana: {
-        identity: {cert: dana_cert, key: dana_key},
-        name: transport.extract_public_key(dana_cert),
+        identity: dana_identity,
+        name: transport.get_name(dana_identity),
         acquaintances
     }
 };
@@ -63,7 +67,13 @@ instantiate_core(
         console.log("HALT", store_name, core.u_fault_msg(core.h_run_loop()));
     }
     debug_device(core);
-    awp_device(core, resume, transport, [stores[store_name]], webcrypto);
+    awp_device(
+        core,
+        resume,
+        transport,
+        [stores[store_name]],
+        crypto.webcrypto
+    );
     return core.h_import(asm_url).then(function (asm_module) {
         core.h_boot(asm_module.boot);
         resume();

--- a/ufork-wasm/lib/grant_matcher.asm
+++ b/ufork-wasm/lib/grant_matcher.asm
@@ -74,11 +74,10 @@ listen_svc_beh:             ; awp_dev <- (cust store . greeter)
     send 5                  ; --
     ref std.commit
 
-listen_cb_beh:              ; cust <- ((stop . info) . reason)
+listen_cb_beh:              ; cust <- (stop . reason)
     msg -1                  ; reason
     is_eq #nil              ; --
-    msg 1                   ; (stop . info)
-    nth 1                   ; stop
+    msg 1                   ; stop
     state 0                 ; stop cust
     ref std.send_msg
 

--- a/ufork-wasm/www/devices/awp_device.js
+++ b/ufork-wasm/www/devices/awp_device.js
@@ -613,7 +613,7 @@ function awp_device(
 
         function resolve(reply) {
 
-// ((stop . info) . reason) -> listen_callback
+// (stop . reason) -> listen_callback
 
             core.h_event_inject(sponsor, listen_callback, reply);
             release_event_stub();
@@ -645,8 +645,8 @@ function awp_device(
             );
 
             // TODO send cancel to cancel_customer
-            const cancel = listen_requestor(function (result, reason) {
-                if (result === undefined) {
+            const cancel = listen_requestor(function (stop, reason) {
+                if (stop === undefined) {
                     console.log("listen fail", reason);
                     return resolve(core.h_reserve_ram({
                         t: core.PAIR_T,
@@ -660,7 +660,7 @@ function awp_device(
 
                 const key = stringify(store.name);
                 if (greeters[key] !== undefined) {
-                    result.stop();
+                    stop();
                     return resolve(core.h_reserve_ram({
                         t: core.PAIR_T,
                         x: core.UNDEF_RAW,
@@ -674,13 +674,13 @@ function awp_device(
                         core.h_release_stub(greeters[key]);
                         delete greeters[key];
                     }
-                    return result.stop();
+                    return stop();
                 }
 
                 stops.push(safe_stop);
                 return resolve(core.h_reserve_ram({
                     t: core.PAIR_T,
-                    x: core.UNDEF_RAW, // TODO (safe_stop . info)
+                    x: core.UNDEF_RAW, // TODO safe_stop
                     y: core.NIL_RAW
                 }));
             });

--- a/ufork-wasm/www/devices/awp_device.js
+++ b/ufork-wasm/www/devices/awp_device.js
@@ -1,6 +1,9 @@
 // Installs the AWP device, allowing cores to communicate over the network via
 // the Actor Wire Protocol.
 
+// Returns a disposal function that destroys all connections and stops
+// listening.
+
 // TODO:
 // - distributed garbage collection
 // - swiss interning
@@ -70,6 +73,7 @@ function awp_device(
     let stubs = Object.create(null);        // swiss -> stub raw    // TODO release at some point
     let handle_to_proxy_key = [];           // handle -> proxy key  // TODO release
     let proxies = Object.create(null);      // proxy key -> data    // TODO drop_proxy
+    let stops = [];                         // listen stop functions // TODO release
 
     function random_swiss() {
         let swiss = new Uint8Array(16); // 128 bits
@@ -673,6 +677,7 @@ function awp_device(
                     return result.stop();
                 }
 
+                stops.push(safe_stop);
                 return resolve(core.h_reserve_ram({
                     t: core.PAIR_T,
                     x: core.UNDEF_RAW, // TODO (safe_stop . info)
@@ -775,78 +780,93 @@ function awp_device(
             }
         }
     );
+
+    return function dispose() {
+        Object.values(connections).forEach(function (connection) {
+            connection.close();
+        });
+        stops.forEach(function (stop_listening) {
+            stop_listening();
+        });
+    };
 }
 
 //debug import {webcrypto} from "node:crypto";
+//debug import parseq from "../parseq.js";
 //debug import instantiate_core from "../ufork.js";
 //debug import debug_device from "./debug_device.js";
 //debug import node_tls_transport from "./node_tls_transport.js";
-//debug const bob_address = {host: "localhost", port: 4001};
-//debug const carol_address = {host: "localhost", port: 4002};
-//debug const alice_cert = "-----BEGIN CERTIFICATE-----\nMIIBlzCB+QIJAKdXgQPMUTS5MAoGCCqGSM49BAMCMBAxDjAMBgNVBAMMBXVmb3JrMB4XDTIzMDYxNTAxMzEzOVoXDTIzMDcxNTAxMzEzOVowEDEOMAwGA1UEAwwFdWZvcmswgZswEAYHKoZIzj0CAQYFK4EEACMDgYYABABAO06FL/42NDAfp8YFC7KZs0ArEM6ocluQe+u7IPkis0kl1O8/6B3FmnR7GfTXQubdc0EFcueKjMyR8D/JY9wDhQAqUjXzVIePzADbfo8vUjrPQ9TBzl+T85XjeBKbDiKZQb8QxeyYlqO246/XksSZJl0vn91gXTbBAR1ZgYeTPd44ljAKBggqhkjOPQQDAgOBjAAwgYgCQgHvlQMSDNJpJTT9/0PsiQIkI2Ui4fJpBDJr1fzYQgVMmnqx5Uvng9DHr1+AU7DDU9+2X1V2OaRsgJAymv1om/vz5wJCAKoHuyWggL9LGkTPUiUqm3dA/JS5dOnKGmdDEqMbEeiofFpt/joV8sdTAw2uigkliw+9vfLMLkJyr2sW3fjiWTBo\n-----END CERTIFICATE-----";
-//debug const alice_key = "-----BEGIN EC PRIVATE KEY-----\nMIHbAgEBBEFCXfqEm5o/WBTMWkHpyz4f+6xqJv7GF+AajgBkyRYMncp6lZInDOKk2aC6oNerZdcDTXnqZ/TKZl1z9OSPkwIsd6AHBgUrgQQAI6GBiQOBhgAEAEA7ToUv/jY0MB+nxgULspmzQCsQzqhyW5B767sg+SKzSSXU7z/oHcWadHsZ9NdC5t1zQQVy54qMzJHwP8lj3AOFACpSNfNUh4/MANt+jy9SOs9D1MHOX5PzleN4EpsOIplBvxDF7JiWo7bjr9eSxJkmXS+f3WBdNsEBHVmBh5M93jiW\n-----END EC PRIVATE KEY-----";
-//debug const bob_cert = "-----BEGIN CERTIFICATE-----\nMIIBlzCB+QIJAMfPBllRxdANMAoGCCqGSM49BAMCMBAxDjAMBgNVBAMMBXVmb3JrMB4XDTIzMDYxNTAxMjYzM1oXDTIzMDcxNTAxMjYzM1owEDEOMAwGA1UEAwwFdWZvcmswgZswEAYHKoZIzj0CAQYFK4EEACMDgYYABACCfQXDKhuHQUQIzpU2HsgZK1n5eziSRHu+/tl67Pso6mSNSiWdhDwObikaOplnFO10IdGaoflbWn+qV3tSXTMYTABd6K9nN7ki/8/Ppoz0It9cqLn60u3RHHPpgrcAEFHpNA/LqItP/t55f6XPArvnt0xIfxjaI4gdwb2uUfnzITruSTAKBggqhkjOPQQDAgOBjAAwgYgCQgEqJCq5FDRvWYC8dMhzzcObvMJJ4FriVRlaEPH94FV1eZIvWLhpSkpzh02+KfiwclO0YJVzGAh7tFEBFZ1U+0A1BAJCAZ9ugBLIqRZXOR+ndUIAs917W9Dw+imQkbiHlKdU8rhGZgA7r29VAfx3A7l+1BmXUrvQRBuU6BoBMxW2BRTQ4wQ1\n-----END CERTIFICATE-----";
-//debug const bob_key = "-----BEGIN EC PRIVATE KEY-----\nMIHbAgEBBEE8BpKem+dZRCbbI33kCwXCADskDId/WhAE7RFRttOnV0m2kxwkad/bDpd20I7dNdUSD5VRk0GsVQacoHtMxdsBlKAHBgUrgQQAI6GBiQOBhgAEAIJ9BcMqG4dBRAjOlTYeyBkrWfl7OJJEe77+2Xrs+yjqZI1KJZ2EPA5uKRo6mWcU7XQh0Zqh+Vtaf6pXe1JdMxhMAF3or2c3uSL/z8+mjPQi31youfrS7dEcc+mCtwAQUek0D8uoi0/+3nl/pc8Cu+e3TEh/GNojiB3Bva5R+fMhOu5J\n-----END EC PRIVATE KEY-----";
-//debug const carol_cert = "-----BEGIN CERTIFICATE-----\nMIIBlzCB+QIJAKXgK2B3FNUbMAoGCCqGSM49BAMCMBAxDjAMBgNVBAMMBXVmb3JrMB4XDTIzMDYxNTAxMDExNFoXDTIzMDcxNTAxMDExNFowEDEOMAwGA1UEAwwFdWZvcmswgZswEAYHKoZIzj0CAQYFK4EEACMDgYYABAD/K8/8lKykhrjH8R6VlEKg2leMjkxBZe/6mzzsymuvD9bn4kDsIj6wjRRaiErlcYisw8ZiJOKlGGAjrIU1ISzitACOZDZ50Xj63N6LQ8rpkoKmbDhWuoD1v0uClMr7IhjG26nsPiHjhJ5UB4FIY/gVu4cci/tkCPgNu4KQUnyYU1SgXTAKBggqhkjOPQQDAgOBjAAwgYgCQgHcMCYkwLybOyQ7ErtE5ucY2CjHStIJWOhgHD/RYrTX4uoXOVl2ISb7F4COQ8Xm1vepNvlWA9PfTbHjXopB6f2D+wJCAZ/Vzcnjsf8wSpm8x34uNYlvo0K+LZNFlQ7EuImKk33QbVR30KAS3y+Ok8yNAucg3Zh1243k09iCFLXmyclcUZgk\n-----END CERTIFICATE-----";
-//debug const carol_key = "-----BEGIN EC PRIVATE KEY-----\nMIHbAgEBBEErmNL2SxVE8Mi13BclwRfR1j/OWNDrt8fMXT8VTzVwfhFBV1XmIXRCB+s4VkQEQWfi69xgA1J1nz/4eWAOuieFoqAHBgUrgQQAI6GBiQOBhgAEAP8rz/yUrKSGuMfxHpWUQqDaV4yOTEFl7/qbPOzKa68P1ufiQOwiPrCNFFqISuVxiKzDxmIk4qUYYCOshTUhLOK0AI5kNnnRePrc3otDyumSgqZsOFa6gPW/S4KUyvsiGMbbqew+IeOEnlQHgUhj+BW7hxyL+2QI+A27gpBSfJhTVKBd\n-----END EC PRIVATE KEY-----";
-//debug const dana_cert = "-----BEGIN CERTIFICATE-----\nMIIBlzCB+QIJAPLWr8RQKQBGMAoGCCqGSM49BAMCMBAxDjAMBgNVBAMMBXVmb3JrMB4XDTIzMDYxNTAxMzIwOVoXDTIzMDcxNTAxMzIwOVowEDEOMAwGA1UEAwwFdWZvcmswgZswEAYHKoZIzj0CAQYFK4EEACMDgYYABAAGfk1CmCfXy63+jOA/S2HgjWiILtTI5R14khfnxzo17+CxdmgiVd3nBtlw8JSP7epZN79Bb+v8sstpBpXPsdJAsQCLEczVVhPA4s32qXM5cPqeua2hOeJAIWs2T2gmJY5NmMsWEksyWKAJRqyks/T37rrCbJXla6r5EtWkDi+zFwVFUDAKBggqhkjOPQQDAgOBjAAwgYgCQgFQMwTdOqg3jFTKcnKagjd6YAFVFsFPEVaZWkLFbpzb7PGOGu8mpB3MGp5381jFjIUK3TEZpvuH54AfWaajtBKCqwJCAdloA77rsAnqlFsz0buZ4nGXSu8eNokvztuDQcFoiCeNtke4NVSdbdclj3xa0LMbLj7ts1sDI/R4t2QT1T2XgFvm\n-----END CERTIFICATE-----";
-//debug const dana_key = "-----BEGIN EC PRIVATE KEY-----\nMIHbAgEBBEGdbH0ztVSCg/8231sFBl07WGdEt26fuMauXcU3Gp24luV+MwaegTDYG7M9CG7LrMvuZipiQPVOgai40b41RzNOjKAHBgUrgQQAI6GBiQOBhgAEAAZ+TUKYJ9fLrf6M4D9LYeCNaIgu1MjlHXiSF+fHOjXv4LF2aCJV3ecG2XDwlI/t6lk3v0Fv6/yyy2kGlc+x0kCxAIsRzNVWE8Dizfapczlw+p65raE54kAhazZPaCYljk2YyxYSSzJYoAlGrKSz9PfuusJsleVrqvkS1aQOL7MXBUVQ\n-----END EC PRIVATE KEY-----";
-//debug instantiate_core(
-//debug     import.meta.resolve(
-//debug         "../../target/wasm32-unknown-unknown/debug/ufork_wasm.wasm"
-//debug     ),
-//debug     console.log
-//debug ).then(function (core) {
-//debug     function resume() {
-//debug         console.log("HALT:", core.u_fault_msg(core.h_run_loop()));
-//debug     }
-//debug     const transport = node_tls_transport();
-//debug     const acquaintances = [
-//debug         {
-//debug             name: transport.extract_public_key(bob_cert),
-//debug             address: bob_address
-//debug         },
-//debug         {
-//debug             name: transport.extract_public_key(carol_cert),
-//debug             address: carol_address
+//debug let transport = node_tls_transport();
+//debug let dispose;
+//debug parseq.parallel([
+//debug     transport.generate_identity(),
+//debug     transport.generate_identity(),
+//debug     transport.generate_identity(),
+//debug     transport.generate_identity()
+//debug ])(function callback(
+//debug     [
+//debug         alice_identity,
+//debug         bob_identity,
+//debug         carol_identity,
+//debug         dana_identity
+//debug     ],
+//debug     ignore
+//debug ) {
+//debug     const bob_address = {host: "localhost", port: 5001};
+//debug     const carol_address = {host: "localhost", port: 5002};
+//debug     instantiate_core(
+//debug         import.meta.resolve(
+//debug             "../../target/wasm32-unknown-unknown/debug/ufork_wasm.wasm"
+//debug         ),
+//debug         console.log
+//debug     ).then(function (core) {
+//debug         function resume() {
+//debug             console.log("HALT:", core.u_fault_msg(core.h_run_loop()));
 //debug         }
-//debug     ];
-//debug     const alice = {
-//debug         identity: {cert: alice_cert, key: alice_key},
-//debug         name: transport.extract_public_key(alice_cert),
-//debug         acquaintances
-//debug     };
-//debug     const bob = {
-//debug         identity: {cert: bob_cert, key: bob_key},
-//debug         name: transport.extract_public_key(bob_cert),
-//debug         address: bob_address,
-//debug         bind_info: bob_address
-//debug     };
-//debug     const carol = {
-//debug         identity: {cert: carol_cert, key: carol_key},
-//debug         name: transport.extract_public_key(carol_cert),
-//debug         address: carol_address,
-//debug         bind_info: carol_address
-//debug     };
-//debug     const dana = {
-//debug         identity: {cert: dana_cert, key: dana_key},
-//debug         name: transport.extract_public_key(dana_cert),
-//debug         acquaintances
-//debug     };
-//debug     debug_device(core);
-//debug     awp_device(
-//debug         core,
-//debug         resume,
-//debug         transport,
-//debug         [alice, bob, carol, dana],
-//debug         webcrypto
-//debug     );
-//debug     return core.h_import(
-//debug         import.meta.resolve("../../lib/grant_matcher.asm")
-//debug     ).then(function (asm_module) {
-//debug         core.h_boot(asm_module.boot);
-//debug         resume();
+//debug         const acquaintances = [
+//debug             {
+//debug                 name: transport.get_name(bob_identity),
+//debug                 address: bob_address
+//debug             },
+//debug             {
+//debug                 name: transport.get_name(carol_identity),
+//debug                 address: carol_address
+//debug             }
+//debug         ];
+//debug         const store = [
+//debug             {
+//debug                 identity: alice_identity,
+//debug                 name: transport.get_name(alice_identity),
+//debug                 acquaintances
+//debug             },
+//debug             {
+//debug                 identity: bob_identity,
+//debug                 name: transport.get_name(bob_identity),
+//debug                 address: bob_address,
+//debug                 bind_info: bob_address
+//debug             },
+//debug             {
+//debug                 identity: carol_identity,
+//debug                 name: transport.get_name(carol_identity),
+//debug                 address: carol_address,
+//debug                 bind_info: carol_address
+//debug             },
+//debug             {
+//debug                 identity: dana_identity,
+//debug                 name: transport.get_name(dana_identity),
+//debug                 acquaintances
+//debug             }
+//debug         ];
+//debug         debug_device(core);
+//debug         dispose = awp_device(core, resume, transport, store, webcrypto);
+//debug         return core.h_import(
+//debug             import.meta.resolve("../../lib/grant_matcher.asm")
+//debug         ).then(function (asm_module) {
+//debug             core.h_boot(asm_module.boot);
+//debug             resume();
+//debug         });
 //debug     });
 //debug });
+//debug // dispose();
 
 export default Object.freeze(awp_device);

--- a/ufork-wasm/www/devices/dummy_transport.js
+++ b/ufork-wasm/www/devices/dummy_transport.js
@@ -127,7 +127,7 @@ function dummy_transport(flakiness = 0) {
                     return callback(undefined, "Address in use.");
                 }
                 listeners[identity + ":" + bind_info] = make_connection;
-                return callback({stop});
+                return callback(stop);
             });
         };
     }
@@ -187,13 +187,13 @@ function dummy_transport(flakiness = 0) {
 //debug     function on_close(ignore, reason) {
 //debug         console.log("bob on_close", reason);
 //debug     }
-//debug )(function listen_callback(result, reason) {
-//debug     if (result === undefined) {
+//debug )(function listen_callback(stop, reason) {
+//debug     if (stop === undefined) {
 //debug         return console.log("bob failed", reason);
 //debug     }
 //debug     if (Math.random() < flake) {
 //debug         console.log("bob stop");
-//debug         return result.stop();
+//debug         return stop();
 //debug     }
 //debug     const cancel_connect = transport.connect(
 //debug         "alice",

--- a/ufork-wasm/www/devices/node_tls_transport.js
+++ b/ufork-wasm/www/devices/node_tls_transport.js
@@ -227,10 +227,7 @@ function listen(identity, bind_info, on_open, on_receive, on_close) {
                 if (cancelled) {
                     return server.close();
                 }
-                callback({
-                    stop,
-                    info: server.address()
-                });
+                callback(stop);
             });
             return function cancel() {
                 cancelled = true;
@@ -328,7 +325,7 @@ function node_tls_transport() {
 //debug     [generate_identity(), generate_identity()]
 //debug )(function ([alice_identity, bob_identity], ignore) {
 //debug     const bob_address = {host: "localhost", port: 4444};
-//debug     const flake = 0;
+//debug     const flake = 0.1;
 //debug     const cancel_listen = listen(
 //debug         bob_identity,
 //debug         bob_address,
@@ -346,11 +343,11 @@ function node_tls_transport() {
 //debug         function on_close(ignore, reason) {
 //debug             console.log("bob on_close", reason);
 //debug         }
-//debug     )(function listen_callback(result, reason) {
-//debug         if (result === undefined) {
+//debug     )(function listen_callback(stop, reason) {
+//debug         if (stop === undefined) {
 //debug             return console.log("bob failed", reason);
 //debug         }
-//debug         console.log("bob listening", result.info);
+//debug         console.log("bob listening");
 //debug         const cancel_connect = connect(
 //debug             alice_identity,
 //debug             get_name(bob_identity),
@@ -364,7 +361,7 @@ function node_tls_transport() {
 //debug                 }
 //debug                 if (Math.random() < flake) {
 //debug                     console.log("bob stop");
-//debug                     result.stop();
+//debug                     stop();
 //debug                 }
 //debug             },
 //debug             function on_close(ignore, reason) {

--- a/ufork-wasm/www/devices/node_tls_transport.js
+++ b/ufork-wasm/www/devices/node_tls_transport.js
@@ -1,55 +1,143 @@
 // A TLS-over-TCP AWP transport for Node.js.
 
 //  name:
-//      A Uint8Array containing raw public key material.
+//      An Ed25519 public key as a 32-byte Uint8Array.
 
 //  address:
 //  bind_info:
 //      An object like {host, port}.
 
 //  identity:
-//      An object like {key, cert} where the key is a PEM-encoded P-521 private
-//      key and cert is a matching PEM-encoded x509 certificate.
+//      A Node.js KeyObject representing a Ed25519 private key.
 
-//      These can be generated with the following commands:
+//      The transport's 'generate_identity' method is a requestor factory that
+//      produces new identities.
 
-//          openssl ecparam -name secp521r1 -genkey -noout > key.pem
-//          openssl req -new -subj /CN=ufork -x509 -key key.pem > cert.pem
-
-//      The 'name' can be obtained from the certificate using the transport's
-//      'extract_public_key' method.
+//      The transport's 'get_name' method takes an identity and returns the
+//      corresponding name.
 
 /*jslint node, long */
 
-import stream from "node:stream";
+import crypto from "node:crypto";
 import tls from "node:tls";
 import oed from "../oed_lite.js";
 
 const min_tls_version = "TLSv1.3";              // more secure than v1.2
-const curve = "secp521r1";                      // P-521
 const ciphers = "TLS_CHACHA20_POLY1305_SHA256"; // no negotiation
 
-function concat(a, b) {
-    let array = new Uint8Array(a.byteLength + b.byteLength);
-    array.set(a, 0);
-    array.set(b, a.byteLength);
-    return array;
+function hex_decode(string) {
+    return Buffer.from(string.replace(/\s/g, ""), "hex");
 }
 
-function extract_public_key(pem) {
+function get_certificate_pem(private_key_object) {
 
-// Node.js does not seem to expose its PEM parsing machinery, but we can still
-// use it in a roundabout way.
+// Node.js does not come with the ability to generate TLS certificates. However,
+// it does expose the necessary cryptographic operations to
 
-    const tls_socket = new tls.TLSSocket(new stream.Transform(), {cert: pem});
-    return new Uint8Array(tls_socket.getCertificate().pubkey);
+//  a) derive the public key from the private key, and
+//  b) sign the TBS (to-be-signed) certificate holding the public key
+
+// allowing us to construct valid certificates using some precomputed material.
+
+// I found https://lapo.it/asn1js very handy in reverse-engineering the
+// certificate format. The template material is based on the output of the
+// following commands:
+
+//      openssl genpkey -algorithm Ed25519 > key.pem
+//      openssl req -new -subj /CN=ufork -x509 -key key.pem > cert.pem
+
+    const prelude = hex_decode(`
+        30 82 01 34
+    `);
+    const tbs_start = hex_decode(`
+                    30 81 E7 A0  03 02 01 02 02 14 1E 7E
+        12 FD 02 50 F4 AD 41 FC  69 C0 65 9B 4C 61 37 B1
+        45 DF 30 05 06 03 2B 65  70 30 10 31 0E 30 0C 06
+        03 55 04 03 0C 05 75 66  6F 72 6B 30 1E 17 0D 32
+        33 30 36 31 36 31 30 35  34 30 39 5A 17 0D 32 33
+        30 37 31 36 31 30 35 34  30 39 5A 30 10 31 0E 30
+        0C 06 03 55 04 03 0C 05  75 66 6F 72 6B
+    `);
+    const public_key_der = crypto.createPublicKey(
+        private_key_object
+    ).export(
+        {type: "spki", format: "der"}
+    );
+    const tbs_end = hex_decode(`
+                                    A3 53 30 51 30 1D 06
+        03 55 1D 0E 04 16 04 14  A7 CC E6 E9 3E 16 9B 7A
+        58 82 C0 A1 41 41 20 F3  7B 35 3F 44 30 1F 06 03
+        55 1D 23 04 18 30 16 80  14 A7 CC E6 E9 3E 16 9B
+        7A 58 82 C0 A1 41 41 20  F3 7B 35 3F 44 30 0F 06
+        03 55 1D 13 01 01 FF 04  05 30 03 01 01 FF
+    `);
+    const signature_algorithm = hex_decode(`
+                                                   30 05
+        06 03 2B 65 70 03 41 00
+    `);
+    const tbs_certificate = Buffer.concat([
+        tbs_start,
+        public_key_der,
+        tbs_end
+    ]);
+    const asn1 = Buffer.concat([
+        prelude,
+        tbs_certificate,
+        signature_algorithm,
+        crypto.sign(undefined, tbs_certificate, private_key_object)
+    ]);
+    return (
+        "-----BEGIN CERTIFICATE-----\n"
+        + asn1.toString("base64")
+        + "\n-----END CERTIFICATE-----"
+    );
+}
+
+function cert_to_pub(der_buffer) {
+
+// Since we constructed the certificate manually, we can reliably predict where
+// the public key will be.
+
+    return der_buffer.slice(121, 153);
+}
+
+function get_name(private_key_object) {
+    return new Uint8Array(
+        crypto.createPublicKey(
+            private_key_object
+        ).export(
+            {type: "spki", format: "der"}
+        ).slice(
+            12 // SEQUENCE, SEQUENCE, OBJECT IDENTIFIER
+        )
+    );
+}
+
+function generate_identity() {
+    return function generate_identity_requestor(callback) {
+        try {
+            crypto.generateKeyPair(
+                "ed25519", // less NSA
+                undefined,
+                function (error, ignore, private_key_object) {
+                    return (
+                        error
+                        ? callback(undefined, error)
+                        : callback(private_key_object)
+                    );
+                }
+            );
+        } catch (exception) {
+            return callback(undefined, exception);
+        }
+    };
 }
 
 function make_consumer(socket, connection, on_receive, on_close) {
-    let remainder = new Uint8Array(0);
+    let remainder = Buffer.from([]);
     return function (chunk) {
-        remainder = concat(remainder, new Uint8Array(chunk));
-        const result = oed.decode(remainder);
+        remainder = Buffer.concat([remainder, chunk]);
+        const result = oed.decode(new Uint8Array(remainder));
         if (result.value === undefined) {
             if (result.error === "offset out-of-bounds") {
 
@@ -68,50 +156,116 @@ function make_consumer(socket, connection, on_receive, on_close) {
     };
 }
 
-function node_tls_transport() {
+function listen(identity, bind_info, on_open, on_receive, on_close) {
+    return function listen_requestor(callback) {
+        let cancelled = false;
+        let server;
+        let connections = [];
+        let reason;
 
-    function listen(identity, bind_info, on_open, on_receive, on_close) {
-        return function listen_requestor(callback) {
-            let cancelled = false;
-            let server;
-            let connections = [];
-            let reason;
+        function stop() {
+            connections.forEach(function (connection) {
+                connection.close();
+            });
+            connections = [];
+            server.close();
+        }
 
-            function stop() {
-                connections.forEach(function (connection) {
-                    connection.close();
-                });
-                connections = [];
-                server.close();
-            }
-
-            try {
-                const {host, port} = bind_info;
-                server = tls.createServer({
-                    key: identity.key,
-                    cert: identity.cert,
-                    rejectUnauthorized: false,
-                    requestCert: true,
-                    minVersion: min_tls_version,
-                    ecdhCurve: curve,
-                    ciphers
-                });
-                server.on("secureConnection", function (socket) {
-                    const certificate = socket.getPeerCertificate();
-                    if (certificate.asn1Curve !== curve) {
-                        return socket.destroy();
-                    }
-                    let destroyed = false;
-                    const connection = Object.freeze({
-                        send(frame) {
+        try {
+            const {host, port} = bind_info;
+            server = tls.createServer({
+                key: identity.export({type: "pkcs8", format: "pem"}),
+                cert: get_certificate_pem(identity),
+                rejectUnauthorized: false,
+                requestCert: true,
+                minVersion: min_tls_version,
+                ciphers
+            });
+            server.on("secureConnection", function (socket) {
+                let destroyed = false;
+                const certificate = socket.getPeerCertificate();
+                const connection = Object.freeze({
+                    send(frame) {
 
 // The frame buffer is encoded as a Raw BLOB with a leading length, used by the
 // receiver to distinguish separate frames.
 
+                        socket.write(oed.encode(frame));
+                    },
+                    name() {
+                        return new Uint8Array(cert_to_pub(certificate.raw));
+                    },
+                    close() {
+                        destroyed = true;
+                        socket.destroy();
+                    }
+                });
+                socket.on("data", make_consumer(
+                    socket,
+                    connection,
+                    on_receive,
+                    on_close
+                ));
+                socket.once("tlsClientError", function (error) {
+                    reason = error;
+                });
+                socket.once("error", function (error) {
+                    reason = error;
+                });
+                socket.once("close", function () {
+                    connections = connections.filter(function (the_conn) {
+                        return the_conn !== connection;
+                    });
+                    if (!destroyed) {
+                        on_close(connection, reason);
+                    }
+                });
+                connections.push(connection);
+                on_open(connection);
+            });
+            server.listen(port, host, function on_listening() {
+                if (cancelled) {
+                    return server.close();
+                }
+                callback({
+                    stop,
+                    info: server.address()
+                });
+            });
+            return function cancel() {
+                cancelled = true;
+            };
+        } catch (exception) {
+            callback(undefined, exception);
+        }
+    };
+}
+
+function connect(identity, name, address, on_receive, on_close) {
+    return function connect_requestor(callback) {
+        let socket;
+        let destroyed = false; // socket.destroyed === true on ECONNREFUSED
+        let connection;
+        let reason;
+        try {
+            const {host, port} = address;
+            socket = tls.connect({
+                port,
+                host,
+                key: identity.export({type: "pkcs8", format: "pem"}),
+                cert: get_certificate_pem(identity),
+                rejectUnauthorized: false,
+                minVersion: min_tls_version,
+                ciphers
+            }, function on_secure_connection() {
+                const certificate = socket.getPeerCertificate();
+                if (cert_to_pub(certificate.raw).equals(name)) {
+                    connection = Object.freeze({
+                        send(frame) {
                             socket.write(oed.encode(frame));
                         },
                         name() {
-                            return new Uint8Array(certificate.pubkey).slice();
+                            return name;
                         },
                         close() {
                             destroyed = true;
@@ -124,194 +278,114 @@ function node_tls_transport() {
                         on_receive,
                         on_close
                     ));
-                    socket.once("tlsClientError", function (error) {
-                        reason = error;
-                    });
-                    socket.once("error", function (error) {
-                        reason = error;
-                    });
-                    socket.once("close", function () {
-                        connections = connections.filter(function (the_conn) {
-                            return the_conn !== connection;
-                        });
-                        if (!destroyed) {
-                            on_close(connection, reason);
-                        }
-                    });
-                    connections.push(connection);
-                    on_open(connection);
-                });
-                server.listen(port, host, function on_listening() {
-                    if (cancelled) {
-                        return server.close();
-                    }
-                    callback({
-                        stop,
-                        info: server.address()
-                    });
-                });
-                return function cancel() {
-                    cancelled = true;
-                };
-            } catch (exception) {
-                callback(undefined, exception);
-            }
-        };
-    }
-
-    function connect(identity, name, address, on_receive, on_close) {
-        return function connect_requestor(callback) {
-            let socket;
-            let destroyed = false; // socket.destroyed === true on ECONNREFUSED
-            let connection;
-            let reason;
-            try {
-                const {host, port} = address;
-                socket = tls.connect({
-                    port,
-                    host,
-                    key: identity.key,
-                    cert: identity.cert,
-                    rejectUnauthorized: false,
-                    minVersion: min_tls_version,
-                    ecdhCurve: curve,
-                    ciphers
-                }, function on_secure_connection() {
-                    const certificate = socket.getPeerCertificate();
-                    if (
-                        certificate.pubkey.equals(name)
-                        && certificate.asn1Curve === curve
-                    ) {
-                        connection = Object.freeze({
-                            send(frame) {
-                                socket.write(oed.encode(frame));
-                            },
-                            name() {
-                                return name;
-                            },
-                            close() {
-                                destroyed = true;
-                                socket.destroy();
-                            }
-                        });
-                        socket.on("data", make_consumer(
-                            socket,
-                            connection,
-                            on_receive,
-                            on_close
-                        ));
-                        callback(connection);
+                    callback(connection);
+                    callback = undefined;
+                } else {
+                    destroyed = true;
+                    socket.destroy();
+                    callback(undefined, "Unexpected public key.");
+                    callback = undefined;
+                }
+            });
+            socket.once("error", function (error) {
+                reason = error;
+            });
+            socket.once("close", function () {
+                if (!destroyed) {
+                    if (callback !== undefined) {
+                        callback(undefined, reason);
                         callback = undefined;
                     } else {
-                        destroyed = true;
-                        socket.destroy();
-                        callback(undefined, "Unexpected public key.");
-                        callback = undefined;
+                        on_close(connection, reason);
                     }
-                });
-                socket.once("error", function (error) {
-                    reason = error;
-                });
-                socket.once("close", function () {
-                    if (!destroyed) {
-                        if (callback !== undefined) {
-                            callback(undefined, reason);
-                            callback = undefined;
-                        } else {
-                            on_close(connection, reason);
-                        }
-                    }
-                });
-                return function cancel() {
-                    if (callback !== undefined) {
-                        destroyed = true;
-                        socket.destroy();
-                    }
-                };
-            } catch (exception) {
-                callback(undefined, exception);
-            }
-        };
-    }
+                }
+            });
+            return function cancel() {
+                if (callback !== undefined) {
+                    destroyed = true;
+                    socket.destroy();
+                }
+            };
+        } catch (exception) {
+            callback(undefined, exception);
+        }
+    };
+}
 
-    return Object.freeze({listen, connect, extract_public_key});
+function node_tls_transport() {
+    return Object.freeze({listen, connect, generate_identity, get_name});
 }
 
 //debug import hex from "./hex.js";
+//debug import parseq from "../parseq.js";
 //debug function halve(buffer) {
 //debug     return new Uint8Array(buffer).slice(
 //debug         0,
 //debug         Math.floor(buffer.length / 2)
 //debug     );
 //debug }
-//debug const transport = node_tls_transport();
-//debug const bob_address = {host: "localhost", port: 4444};
-//debug const bob_identity = {
-//debug     cert: "-----BEGIN CERTIFICATE-----\nMIIBlzCB+QIJAMfPBllRxdANMAoGCCqGSM49BAMCMBAxDjAMBgNVBAMMBXVmb3JrMB4XDTIzMDYxNTAxMjYzM1oXDTIzMDcxNTAxMjYzM1owEDEOMAwGA1UEAwwFdWZvcmswgZswEAYHKoZIzj0CAQYFK4EEACMDgYYABACCfQXDKhuHQUQIzpU2HsgZK1n5eziSRHu+/tl67Pso6mSNSiWdhDwObikaOplnFO10IdGaoflbWn+qV3tSXTMYTABd6K9nN7ki/8/Ppoz0It9cqLn60u3RHHPpgrcAEFHpNA/LqItP/t55f6XPArvnt0xIfxjaI4gdwb2uUfnzITruSTAKBggqhkjOPQQDAgOBjAAwgYgCQgEqJCq5FDRvWYC8dMhzzcObvMJJ4FriVRlaEPH94FV1eZIvWLhpSkpzh02+KfiwclO0YJVzGAh7tFEBFZ1U+0A1BAJCAZ9ugBLIqRZXOR+ndUIAs917W9Dw+imQkbiHlKdU8rhGZgA7r29VAfx3A7l+1BmXUrvQRBuU6BoBMxW2BRTQ4wQ1\n-----END CERTIFICATE-----",
-//debug     key: "-----BEGIN EC PRIVATE KEY-----\nMIHbAgEBBEE8BpKem+dZRCbbI33kCwXCADskDId/WhAE7RFRttOnV0m2kxwkad/bDpd20I7dNdUSD5VRk0GsVQacoHtMxdsBlKAHBgUrgQQAI6GBiQOBhgAEAIJ9BcMqG4dBRAjOlTYeyBkrWfl7OJJEe77+2Xrs+yjqZI1KJZ2EPA5uKRo6mWcU7XQh0Zqh+Vtaf6pXe1JdMxhMAF3or2c3uSL/z8+mjPQi31youfrS7dEcc+mCtwAQUek0D8uoi0/+3nl/pc8Cu+e3TEh/GNojiB3Bva5R+fMhOu5J\n-----END EC PRIVATE KEY-----"
-//debug };
-//debug const alice_identity = {
-//debug     cert: "-----BEGIN CERTIFICATE-----\nMIIBlzCB+QIJAKXgK2B3FNUbMAoGCCqGSM49BAMCMBAxDjAMBgNVBAMMBXVmb3JrMB4XDTIzMDYxNTAxMDExNFoXDTIzMDcxNTAxMDExNFowEDEOMAwGA1UEAwwFdWZvcmswgZswEAYHKoZIzj0CAQYFK4EEACMDgYYABAD/K8/8lKykhrjH8R6VlEKg2leMjkxBZe/6mzzsymuvD9bn4kDsIj6wjRRaiErlcYisw8ZiJOKlGGAjrIU1ISzitACOZDZ50Xj63N6LQ8rpkoKmbDhWuoD1v0uClMr7IhjG26nsPiHjhJ5UB4FIY/gVu4cci/tkCPgNu4KQUnyYU1SgXTAKBggqhkjOPQQDAgOBjAAwgYgCQgHcMCYkwLybOyQ7ErtE5ucY2CjHStIJWOhgHD/RYrTX4uoXOVl2ISb7F4COQ8Xm1vepNvlWA9PfTbHjXopB6f2D+wJCAZ/Vzcnjsf8wSpm8x34uNYlvo0K+LZNFlQ7EuImKk33QbVR30KAS3y+Ok8yNAucg3Zh1243k09iCFLXmyclcUZgk\n-----END CERTIFICATE-----",
-//debug     key: "-----BEGIN EC PRIVATE KEY-----\nMIHbAgEBBEErmNL2SxVE8Mi13BclwRfR1j/OWNDrt8fMXT8VTzVwfhFBV1XmIXRCB+s4VkQEQWfi69xgA1J1nz/4eWAOuieFoqAHBgUrgQQAI6GBiQOBhgAEAP8rz/yUrKSGuMfxHpWUQqDaV4yOTEFl7/qbPOzKa68P1ufiQOwiPrCNFFqISuVxiKzDxmIk4qUYYCOshTUhLOK0AI5kNnnRePrc3otDyumSgqZsOFa6gPW/S4KUyvsiGMbbqew+IeOEnlQHgUhj+BW7hxyL+2QI+A27gpBSfJhTVKBd\n-----END EC PRIVATE KEY-----"
-//debug };
-//debug const flake = 0;
-//debug let cancel_connect;
-//debug let cancel_listen = transport.listen(
-//debug     bob_identity,
-//debug     bob_address,
-//debug     function on_open(connection) {
-//debug         console.log("bob on_open", hex.encode(connection.name()));
-//debug     },
-//debug     function on_receive(connection, frame_buffer) {
-//debug         console.log("bob on_receive", frame_buffer);
-//debug         if (frame_buffer.length > 0) {
-//debug             connection.send(halve(frame_buffer));
-//debug         } else {
-//debug             connection.close();
-//debug         }
-//debug     },
-//debug     function on_close(ignore, reason) {
-//debug         console.log("bob on_close", reason);
-//debug     }
-//debug )(function listen_callback(result, reason) {
-//debug     if (result === undefined) {
-//debug         return console.log("bob failed", reason);
-//debug     }
-//debug     console.log("bob listening", result.info);
-//debug     cancel_connect = transport.connect(
-//debug         alice_identity,
-//debug         extract_public_key(bob_identity.cert),
+//debug parseq.parallel(
+//debug     [generate_identity(), generate_identity()]
+//debug )(function ([alice_identity, bob_identity], ignore) {
+//debug     const bob_address = {host: "localhost", port: 4444};
+//debug     const flake = 0;
+//debug     const cancel_listen = listen(
+//debug         bob_identity,
 //debug         bob_address,
+//debug         function on_open(connection) {
+//debug             console.log("bob on_open", hex.encode(connection.name()));
+//debug         },
 //debug         function on_receive(connection, frame_buffer) {
-//debug             console.log("alice on_receive", frame_buffer);
+//debug             console.log("bob on_receive", frame_buffer);
 //debug             if (frame_buffer.length > 0) {
 //debug                 connection.send(halve(frame_buffer));
 //debug             } else {
 //debug                 connection.close();
 //debug             }
-//debug             if (Math.random() < flake) {
-//debug                 console.log("bob stop");
-//debug                 result.stop();
-//debug             }
 //debug         },
 //debug         function on_close(ignore, reason) {
-//debug             console.log("alice on_close", reason);
+//debug             console.log("bob on_close", reason);
 //debug         }
-//debug     )(function connect_callback(connection, reason) {
-//debug         if (connection === undefined) {
-//debug             return console.log("alice failed", reason);
+//debug     )(function listen_callback(result, reason) {
+//debug         if (result === undefined) {
+//debug             return console.log("bob failed", reason);
 //debug         }
-//debug         console.log("alice on_open", hex.encode(connection.name()));
-//debug         connection.send(new Uint8Array(1e5));
+//debug         console.log("bob listening", result.info);
+//debug         const cancel_connect = connect(
+//debug             alice_identity,
+//debug             get_name(bob_identity),
+//debug             bob_address,
+//debug             function on_receive(connection, frame_buffer) {
+//debug                 console.log("alice on_receive", frame_buffer);
+//debug                 if (frame_buffer.length > 0) {
+//debug                     connection.send(halve(frame_buffer));
+//debug                 } else {
+//debug                     connection.close();
+//debug                 }
+//debug                 if (Math.random() < flake) {
+//debug                     console.log("bob stop");
+//debug                     result.stop();
+//debug                 }
+//debug             },
+//debug             function on_close(ignore, reason) {
+//debug                 console.log("alice on_close", reason);
+//debug             }
+//debug         )(function connect_callback(connection, reason) {
+//debug             if (connection === undefined) {
+//debug                 return console.log("alice failed", reason);
+//debug             }
+//debug             console.log("alice on_open", hex.encode(connection.name()));
+//debug             connection.send(new Uint8Array(1e5));
+//debug         });
+//debug         if (Math.random() < flake) {
+//debug             console.log("alice cancel");
+//debug             cancel_connect();
+//debug         }
 //debug     });
 //debug     if (Math.random() < flake) {
-//debug         console.log("alice cancel");
-//debug         cancel_connect();
+//debug         console.log("bob cancel");
+//debug         cancel_listen();
 //debug     }
 //debug });
-//debug if (Math.random() < flake) {
-//debug     console.log("bob cancel");
-//debug     cancel_listen();
-//debug }
 
 export default Object.freeze(node_tls_transport);


### PR DESCRIPTION
Previously, it was necessary to use openssl to generate a party's identity, consisting of both a certificate and a private key. Now, the TLS transport derives the certificate from the party's private key, making identities much more compact and simpler to generate on the fly.