### PR TITLE
improve efficiency and security of WebRTC signalling

### DIFF
--- a/ufork-wasm/examples/grant_matcher/README.md
+++ b/ufork-wasm/examples/grant_matcher/README.md
@@ -39,14 +39,14 @@ Firstly, start the web server:
         --allow-net \
         --allow-read=. \
         examples/grant_matcher/webrtc.js \
-        127.0.0.1:4455
+        localhost:4455
 
 In separate browser tabs, navigate to the following URLs:
 
-    http://127.0.0.1:4455/gm
-    http://127.0.0.1:4455/keqd
-    http://127.0.0.1:4455/donor
-    http://127.0.0.1:4455/donor
+    http://localhost:4455/gm
+    http://localhost:4455/keqd
+    http://localhost:4455/donor
+    http://localhost:4455/donor
 
 In each of the donor tabs, copy the names from the GM and KEQD tabs and
 press "Start". The donors will then attempt to connect to the GM and KEQD

--- a/ufork-wasm/examples/grant_matcher/party.js
+++ b/ufork-wasm/examples/grant_matcher/party.js
@@ -21,7 +21,7 @@ function party(asm_url, acquaintance_names = []) {
         pre.textContent += "\n" + things.join(" ");
     }
 
-    const signaller_url = (
+    const signaller_origin = (
         location.protocol === "https:"
         ? "wss://"
         : "ws://"
@@ -60,12 +60,19 @@ function party(asm_url, acquaintance_names = []) {
             awp_device(core, transport, [{
                 identity,
                 name,
-                address: signaller_url,
-                bind_info: signaller_url,
+                address: signaller_origin + "/connect?name=" + hex.encode(name),
+                bind_info: (
+                    signaller_origin
+                    + "/listen?name=" + hex.encode(name)
+                    + "&password=uFork"
+                ),
                 acquaintances: acquaintance_names.map(function (name) {
                     return {
                         name,
-                        address: signaller_url
+                        address: (
+                            signaller_origin
+                            + "/connect?name=" + hex.encode(name)
+                        )
                     };
                 })
             }]);

--- a/ufork-wasm/examples/grant_matcher/webrtc.js
+++ b/ufork-wasm/examples/grant_matcher/webrtc.js
@@ -1,6 +1,6 @@
 // Runs a Deno server supporting the Grant Matcher browser demo.
 
-/*jslint deno, devel */
+/*jslint deno */
 
 import {toFileUrl} from "https://deno.land/std@0.111.0/path/mod.ts";
 import start_server from "../../www/transports/websockets_signalling_server.js";
@@ -15,7 +15,7 @@ const mime_types = {
 
 start_server(
     {hostname, port: Number(port_string)},
-    console.log,
+    window.console.log,
     function on_unhandled_request(request, respond_with) {
         const {pathname} = new URL(request.url);
         const extension = pathname.split(".").pop();

--- a/ufork-wasm/www/devices/awp_device.js
+++ b/ufork-wasm/www/devices/awp_device.js
@@ -804,7 +804,14 @@ function awp_device(
 //debug );
 //debug let dispose;
 //debug let core;
-//debug function demo({transport, bob_address, carol_address, webcrypto}) {
+//debug function demo({
+//debug     transport,
+//debug     bob_address,
+//debug     bob_bind_info = bob_address,
+//debug     carol_address,
+//debug     carol_bind_info = carol_address,
+//debug     webcrypto
+//debug }) {
 //debug     return parseq.sequence([
 //debug         instantiate_core(
 //debug             wasm_url,
@@ -855,13 +862,13 @@ function awp_device(
 //debug                     identity: bob_identity,
 //debug                     name: transport.identity_to_name(bob_identity),
 //debug                     address: bob_address,
-//debug                     bind_info: bob_address
+//debug                     bind_info: bob_bind_info
 //debug                 },
 //debug                 {
 //debug                     identity: carol_identity,
 //debug                     name: transport.identity_to_name(carol_identity),
 //debug                     address: carol_address,
-//debug                     bind_info: carol_address
+//debug                     bind_info: carol_bind_info
 //debug                 },
 //debug                 {
 //debug                     identity: dana_identity,
@@ -885,8 +892,10 @@ function awp_device(
 //debug if (typeof window === "object") {
 //debug     demo({
 //debug         transport: webrtc_transport(dummy_signaller(), console.log),
-//debug         bob_address: "ws://127.0.0.1:4455",
-//debug         carol_address: "ws://127.0.0.1:4455",
+//debug         bob_address: "connect:?name=bob",
+//debug         bob_bind_info: "listen:?name=bob",
+//debug         carol_address: "connect:?name=carol",
+//debug         carol_bind_info: "listen:?name=carol",
 //debug         webcrypto: crypto
 //debug     })(console.log);
 //debug }

--- a/ufork-wasm/www/transports/node_tls_transport.js
+++ b/ufork-wasm/www/transports/node_tls_transport.js
@@ -1,4 +1,5 @@
-// A TLS-over-TCP AWP transport for Node.js.
+// A TLS-based AWP transport for Node.js. Note that this transport suffers from
+// head-of-line blocking because it uses TCP.
 
 // It expects the following types as its parameters:
 


### PR DESCRIPTION
Previously, signalling was symmetric. Connecting and listening parties both used the signalling server in the same way - by subscribing to signals destined for a name. The signalling server blindly trusted subscribing parties to give their real name, making it trivial to eavesdrop on signals intended for others. While this was not a security risk per se, it did make a DoS attack trivial to implement. (This approach was also very inefficient for listening parties, because often a bunch of identical connections would be made to the signalling server and they would all receive the same signals.)

While there is no easy way for the signalling server to verify a party's name (because a name is an RTCCertificate fingerprint), it is possible to demand credentials from parties attempting to listen while providing an unhindered endpoint for parties attempting to connect. (The credentials are a static password, "uFork", until we come up with something better.)

This commit introduces asymmetric signalling: there are now different endpoints for connecting and listening. I also managed to save a round trip by encoding the SDP offer in a URL, which is nice.