### PR TITLE
Host device

### DIFF
--- a/asm.md
+++ b/asm.md
@@ -198,8 +198,8 @@ _n_ _m_              | `cmp` `lt`          | _bool_       | `#t` if _n_ < _m_, o
 _n_ _m_              | `cmp` `le`          | _bool_       | `#t` if _n_ <= _m_, otherwise `#f`
 _n_ _m_              | `cmp` `ge`          | _bool_       | `#t` if _n_ >= _m_, otherwise `#f`
 _n_ _m_              | `cmp` `gt`          | _bool_       | `#t` if _n_ > _m_, otherwise `#f`
-_bool_               | `if` _T_ [_F_]      | —            | if _bool_ is not falsey<sup>*</sup>, continue _T_ (else _F_)
-_bool_               | `if_not` _F_ [_T_]  | —            | if _bool_ is falsey<sup>*</sup>, continue _F_ (else _T_)
+_bool_               | `if` _T_ [_F_]      | —            | if _bool_ is not falsy<sup>*</sup>, continue _T_ (else _F_)
+_bool_               | `if_not` _F_ [_T_]  | —            | if _bool_ is falsy<sup>*</sup>, continue _F_ (else _T_)
 … _tail_ _head_      | `pair` _n_          | _pair_       | create _pair_ from _head_ and _tail_ (_n_ times)
 _pair_               | `part` _n_          | … _tail_ _head_ | split _pair_ into _head_ and _tail_ (_n_ times)
 _pair_               | `nth` _n_           | _itemₙ_      | copy item _n_ from a _pair_ list
@@ -256,7 +256,7 @@ _actual_             | `is_ne` _expect_    | —            | assert _actual_ !=
 —                    | `debug`             | —            | debugger breakpoint
 
 <sup>*</sup> For conditionals (`if` and `if_not`) the values
-`#f`, `#?`, `#nil`, and `0` are considered "falsey".
+`#f`, `#?`, `#nil`, and `0` are considered "falsy".
 
 Every instruction (except `end`) takes a continuation as its
 final operand. In the following example, the `msg` instruction continues to

--- a/c_src/vm.md
+++ b/c_src/vm.md
@@ -117,7 +117,7 @@ _n_ _m_           | {x:VM_cmp, y:LT, z:_K_}       | _bool_   | `TRUE` if _n_ < _
 _n_ _m_           | {x:VM_cmp, y:LE, z:_K_}       | _bool_   | `TRUE` if _n_ <= _m_, otherwise `FALSE`
 _n_ _m_           | {x:VM_cmp, y:NE, z:_K_}       | _bool_   | `TRUE` if _n_ != _m_, otherwise `FALSE`
 _n_ _c_           | {x:VM_cmp, y:CLS, z:_K_}      | _bool_   | `TRUE` if _n_ in _c_, otherwise `FALSE`
-_bool_            | {x:VM_if, y:_T_, z:_F_}       | &mdash;  | continue _F_ if "falsey", otherwise continue _T_
+_bool_            | {x:VM_if, y:_T_, z:_F_}       | &mdash;  | continue _F_ if "falsy", otherwise continue _T_
 &mdash;           | {x:VM_msg, y:0, z:_K_}        | _msg_    | copy event message to stack
 &mdash;           | {x:VM_msg, y:_n_, z:_K_}      | _msg_<sub>_n_</sub> | copy message item _n_ to stack
 &mdash;           | {x:VM_msg, y:-_n_, z:_K_}     | _tail_<sub>_n_</sub> | copy message tail _n_ to stack

--- a/ufork-wasm/examples/grant_matcher/party.js
+++ b/ufork-wasm/examples/grant_matcher/party.js
@@ -6,6 +6,7 @@ import requestorize from "../../www/requestors/requestorize.js";
 import lazy from "../../www/requestors/lazy.js";
 import ufork from "../../www/ufork.js";
 import awp_device from "../../www/devices/awp_device.js";
+import host_device from "../../www/devices/host_device.js";
 import webrtc_transport from "../../www/transports/webrtc_transport.js";
 import websockets_signaller from "../../www/transports/websockets_signaller.js";
 
@@ -60,7 +61,8 @@ function party(asm_url, acquaintance_names = []) {
         requestorize(function ([asm_module, identity]) {
             const name = transport.identity_to_name(identity);
             const address = signaller_origin;
-            awp_device(core, transport, [{
+            const make_dynamic_device = host_device(core);
+            awp_device(core, make_dynamic_device, transport, [{
                 identity,
                 bind_info: {
                     origin: signaller_origin,

--- a/ufork-wasm/examples/grant_matcher/tls.js
+++ b/ufork-wasm/examples/grant_matcher/tls.js
@@ -9,6 +9,7 @@ import parseq from "../../www/parseq.js";
 import lazy from "../../www/requestors/lazy.js";
 import requestorize from "../../www/requestors/requestorize.js";
 import awp_device from "../../www/devices/awp_device.js";
+import host_device from "../../www/devices/host_device.js";
 import node_tls_transport from "../../www/transports/node_tls_transport.js";
 
 const transport = node_tls_transport();
@@ -85,8 +86,10 @@ parseq.sequence([
         return core.h_import(asm_url);
     }),
     requestorize(function (asm_module) {
+        const make_dynamic_device = host_device(core);
         awp_device(
             core,
+            make_dynamic_device,
             transport,
             [stores[store_name]],
             crypto.webcrypto

--- a/ufork-wasm/examples/peer_chat/chat.js
+++ b/ufork-wasm/examples/peer_chat/chat.js
@@ -10,6 +10,7 @@ import io_device from "../../www/devices/io_device.js";
 import blob_device from "../../www/devices/blob_device.js";
 import timer_device from "../../www/devices/timer_device.js";
 import awp_device from "../../www/devices/awp_device.js";
+import host_device from "../../www/devices/host_device.js";
 import dummy_signaller from "../../www/transports/dummy_signaller.js";
 import webrtc_transport from "../../www/transports/webrtc_transport.js";
 import parseq from "../../www/parseq.js";
@@ -181,7 +182,8 @@ parseq.sequence([
         blob_device(core);
         timer_device(core);
         awp_store = the_awp_store;
-        awp_device(core, transport, the_awp_store);
+        const make_dynamic_device = host_device(core);
+        awp_device(core, make_dynamic_device, transport, the_awp_store);
         return boot(asm_module.boot);
     })
 ])(console.log);

--- a/ufork-wasm/lib/dev.asm
+++ b/ufork-wasm/lib/dev.asm
@@ -3,6 +3,8 @@
 .import
     std: "./std.asm"
 
+; Hard-coded devices.
+
 debug_key:
     ref 2
 clock_key:
@@ -15,9 +17,13 @@ timer_key:
     ref 6
 memo_key:
     ref 7
-awp_key:
+host_key:
     ref 8
 
+; Dynamic devices. These are provided by the host device.
+
+awp_key:
+    ref 100
 intro_tag:
     ref 0
 listen_tag:
@@ -105,6 +111,7 @@ count:                  ; () <- n
     blob_key
     timer_key
     memo_key
+    host_key
     awp_key
     intro_tag
     listen_tag

--- a/ufork-wasm/lib/host_device.asm
+++ b/ufork-wasm/lib/host_device.asm
@@ -1,0 +1,24 @@
+; Test suite for the host device.
+
+.import
+    std: "./std.asm"
+
+dummy_key:
+    ref 1000
+proxy_key:
+    ref 1001
+
+boot:                   ; () <- {caps}
+    push -42            ; -42
+    msg 0               ; -42 {caps}
+    push proxy_key      ; -42 {caps} proxy_key
+    dict get            ; -42 proxy
+    send -1             ; --
+    push 42             ; 42
+    msg 0               ; 42 {caps}
+    push dummy_key      ; 42 {caps} dummy_key
+    dict get            ; 42 dummy_dev
+    ref std.send_msg
+
+.export
+    boot

--- a/ufork-wasm/lib/requestors/README.md
+++ b/ufork-wasm/lib/requestors/README.md
@@ -20,11 +20,11 @@ the 'reason' for the cancellation, and can be any value.
 The 'callback' actor is sent a "result" when the request completes (which could
 be never). The result is a pair whose tail indicates success or failure.
 
-On success, the result's tail is falsey and its head is the output value.
+On success, the result's tail is falsy and its head is the output value.
 
     (value) -> callback
 
-On failure, the result's tail is the reason and must not be falsey. The head
+On failure, the result's tail is the reason and must not be falsy. The head
 is #?.
 
     (#? . reason) -> callback

--- a/ufork-wasm/lib/requestors/README.md
+++ b/ufork-wasm/lib/requestors/README.md
@@ -1,8 +1,8 @@
 # Requestors
 
 Actors with the following message signature are called "requestors". Requestors
-support cancellation and failure notification. They take an optional 'value'.
-The message sent to a requestor is a "request".
+support cancellation and failure notification. They take an optional
+input 'value'. The message sent to a requestor is a "request".
 
     (to_cancel callback . value) -> requestor
 
@@ -17,14 +17,14 @@ the 'reason' for the cancellation, and can be any value.
 
     reason -> cancel
 
-The 'callback' actor receives a pair when the request completes (which could be
-never). The value of the tail indicates success or failure.
+The 'callback' actor is sent a "result" when the request completes (which could
+be never). The result is a pair whose tail indicates success or failure.
 
-On success, the tail of the pair is falsy and the head of the pair is the
-resulting value.
+On success, the result's tail is falsey and its head is the output value.
 
     (value) -> callback
 
-On failure, the tail is the reason and must be truthy. The head is #?.
+On failure, the result's tail is the reason and must not be falsey. The head
+is #?.
 
     (#? . reason) -> callback

--- a/ufork-wasm/lib/requestors/canceller.asm
+++ b/ufork-wasm/lib/requestors/canceller.asm
@@ -1,9 +1,14 @@
 ; The "canceller" actor can be passed as the 'to_cancel' capability in a request
 ; message. You can pretty much treat it like the cancel capability that the
-; requestor may eventually send. The only caveat is that the reason is expected
-; to be wrapped in a list:
+; requestor may eventually send.
+
+; It is rare to provide a meaningful reason for cancellation, but if it is then
+; the reason must be wrapped in a list:
 
 ;   (reason) -> canceller
+
+; A more cancel-like capability can be derived from a canceller by wrapping it
+; in 'wrap_beh' from lib.asm.
 
 .import
     std: "../std.asm"
@@ -14,9 +19,7 @@ beh:
 canceller_beh:                  ; () <- message
     msg 0                       ; message
     typeq #actor_t              ; cap?
-    if got_cancel got_reason    ; --
-
-got_cancel:
+    if_not got_reason           ; --
     msg 0                       ; cancel
     push wait_for_reason_beh    ; cancel wait_for_reason_beh
     beh -1                      ; --
@@ -28,22 +31,20 @@ got_reason:
     beh -1                      ; --
     ref std.commit
 
-wait_for_reason_beh:            ; cancel <- message
-    msg 0                       ; message
-    typeq #actor_t              ; cap?
-    if got_cancel               ; --
-    msg 1                       ; reason
-    state 0                     ; reason cancel
-    ref send_reason_to_cancel
-
 wait_for_cancel_beh:            ; (reason) <- message
     msg 0                       ; message
     typeq #actor_t              ; cap?
-    if_not got_reason           ; --
+    if_not std.commit           ; --
     state 1                     ; reason
     msg 0                       ; reason cancel
     ref send_reason_to_cancel
 
+wait_for_reason_beh:            ; cancel <- message
+    msg 0                       ; message
+    typeq #actor_t              ; cap?
+    if std.commit               ; --
+    msg 1                       ; reason
+    state 0                     ; reason cancel
 send_reason_to_cancel:          ; reason cancel
     push std.sink_beh           ; reason cancel sink_beh
     beh 0                       ; reason cancel
@@ -56,49 +57,49 @@ boot:                   ; () <- {caps}
 ; Cancel arrives before reason.
 
     msg 0               ; {caps}
-    push 50             ; {caps} cancel_delay
-    push 100            ; {caps} cancel_delay reason_delay
-    push 42             ; {caps} cancel_delay reason_delay reason
-    push test_beh       ; {caps} cancel_delay reason_delay reason test_beh
-    new 3               ; {caps} test_msg_is_cancel
+    push 50             ; {caps} cancel_ms
+    push 100            ; {caps} cancel_ms reason_ms
+    push 42             ; {caps} cancel_ms reason_ms reason
+    push test_beh       ; {caps} cancel_ms reason_ms reason test_beh
+    new 3               ; {caps} test=test_beh.(reason reason_ms cancel_ms)
     send -1             ; --
 
 ; Reason arrives before cancel.
 
     msg 0               ; {caps}
-    push 100            ; {caps} cancel_delay
-    push 50             ; {caps} cancel_delay reason_delay
-    push 1729           ; {caps} cancel_delay reason_delay reason
-    push test_beh       ; {caps} cancel_delay reason_delay reason test_beh
-    new 3               ; {caps} test_msg_is_reason
+    push 100            ; {caps} cancel_ms
+    push 50             ; {caps} cancel_ms reason_ms
+    push 1729           ; {caps} cancel_ms reason_ms reason
+    push test_beh       ; {caps} cancel_ms reason_ms reason test_beh
+    new 3               ; {caps} test=test_beh.(reason reason_ms cancel_ms)
     send -1             ; --
     ref std.commit
 
 ; We create a canceller and send it a cancel capability and a reason, each after
 ; a different delay. Each is sent twice, to test the canceller's tolerance.
 
-test_beh:               ; (reason reason_delay cancel_delay) <- {caps}
+test_beh:               ; (reason reason_ms cancel_ms) <- {caps}
     push canceller_beh  ; canceller_beh
-    new 0               ; canceller
+    new 0               ; canceller=canceller_beh.()
     state 0             ; canceller (reason ...)
     pick 2              ; canceller (reason ...) canceller
-    state 2             ; canceller (reason ...) canceller reason_delay
-    msg 0               ; canceller (reason ...) canceller reason_delay {caps}
-    push dev.timer_key  ; canceller (reason ...) canceller reason_delay {caps} timer_key
-    dict get            ; canceller (reason ...) canceller reason_delay timer_dev
-    dup 4               ; ... (reason ...) canceller reason_delay timer_dev
-    send 3              ; ... (reason ...) canceller reason_delay timer_dev
+    state 2             ; canceller (reason ...) canceller reason_ms
+    msg 0               ; canceller (reason ...) canceller reason_ms {caps}
+    push dev.timer_key  ; canceller (reason ...) canceller reason_ms {caps} timer_key
+    dict get            ; canceller (reason ...) canceller reason_ms timer_dev
+    dup 4               ; ... (reason ...) canceller reason_ms timer_dev
+    send 3              ; ... (reason ...) canceller reason_ms timer_dev
     send 3              ; canceller
     msg 0               ; canceller {caps}
     push dev.debug_key  ; canceller {caps} debug_key
     dict get            ; canceller debug_dev
     pick 2              ; canceller debug_dev canceller
-    state 3             ; canceller debug_dev canceller cancel_delay
-    msg 0               ; canceller debug_dev canceller cancel_delay {caps}
-    push dev.timer_key  ; canceller debug_dev canceller cancel_delay {caps} timer_key
-    dict get            ; canceller debug_dev canceller cancel_delay timer_dev
-    dup 4               ; ... debug_dev canceller cancel_delay timer_dev
-    send 3              ; ... debug_dev canceller cancel_delay timer_dev
+    state 3             ; canceller debug_dev canceller cancel_ms
+    msg 0               ; canceller debug_dev canceller cancel_ms {caps}
+    push dev.timer_key  ; canceller debug_dev canceller cancel_ms {caps} timer_key
+    dict get            ; canceller debug_dev canceller cancel_ms timer_dev
+    dup 4               ; ... debug_dev canceller cancel_ms timer_dev
+    send 3              ; ... debug_dev canceller cancel_ms timer_dev
     send 3              ; canceller
     ref std.commit
 

--- a/ufork-wasm/lib/requestors/delay.asm
+++ b/ufork-wasm/lib/requestors/delay.asm
@@ -27,14 +27,14 @@ boot:                       ; () <- {caps}
     push #?                 ; 42 debug_dev to_cancel=#?
     pair 2                  ; request=(#? debug_dev . 42)
     push thru.beh           ; request thru_beh
-    new 0                   ; request thru
+    new 0                   ; request thru=thru_beh.()
     msg 0                   ; request thru {caps}
     push dev.timer_key      ; request thru {caps} timer_key
     dict get                ; request thru timer_dev
     push 1000               ; request thru timer_dev delay=1000ms
     roll 3                  ; request timer_dev delay thru
     push delay_beh          ; request timer_dev delay thru delay_beh
-    new 3                   ; request delay
+    new 3                   ; request delay=delay_beh.(thru delay timer_dev)
     ref std.send_msg
 
 .export

--- a/ufork-wasm/lib/requestors/thru.asm
+++ b/ufork-wasm/lib/requestors/thru.asm
@@ -5,7 +5,7 @@
     dev: "../dev.asm"
 
 beh:
-thru_beh:                   ; () <- (to_cancel callback . value)
+thru_beh:                   ; () <- request=(to_cancel callback . value)
     msg -2                  ; value
     msg 2                   ; value callback
     send 1                  ; --
@@ -21,7 +21,7 @@ boot:                       ; () <- {caps}
     push #?                 ; 42 debug_dev to_cancel=#?
     pair 2                  ; request=(#? debug_dev . 42)
     push thru_beh           ; request thru_beh
-    new 0                   ; request thru
+    new 0                   ; request thru=thru_beh.()
     ref std.send_msg
 
 .export

--- a/ufork-wasm/lib/requestors/timeout.asm
+++ b/ufork-wasm/lib/requestors/timeout.asm
@@ -19,9 +19,9 @@ timeout_beh:                ; (requestor time_limit timer_dev) <- request
 ; Create two cancellers, one for the requestor and one for the timer.
 
     push canceller.beh      ; canceller_beh
-    new 0                   ; t␘
+    new 0                   ; t␘=canceller_beh.()
     push canceller.beh      ; t␘ canceller_beh
-    new 0                   ; t␘ r␘
+    new 0                   ; t␘ r␘=canceller_beh.()
 
 ; Does the request contain a 'to_cancel' capability? If not, jump to 'race'.
 
@@ -34,7 +34,7 @@ timeout_beh:                ; (requestor time_limit timer_dev) <- request
 
     dup 2                   ; t␘ r␘ t␘ r␘
     push cancel_all_beh     ; t␘ r␘ t␘ r␘ cancel_all_beh
-    new 2                   ; t␘ r␘ cancel_all
+    new 2                   ; t␘ r␘ cancel_all=cancel_all_beh.(r␘ t␘)
     msg 1                   ; t␘ r␘ cancel_all to_cancel
     send -1                 ; t␘ r␘
 
@@ -44,12 +44,12 @@ timeout_beh:                ; (requestor time_limit timer_dev) <- request
 race:
     msg 2                   ; t␘ r␘ raw_callback
     push lib.once_beh       ; t␘ r␘ raw_callback once_beh
-    new 1                   ; t␘ r␘ callback
+    new 1                   ; t␘ r␘ callback=once_beh.(raw_callback)
     msg -2                  ; t␘ r␘ callback value
     pick 4                  ; t␘ r␘ callback value t␘
     pick 3                  ; t␘ r␘ callback value t␘ callback
     push win_beh            ; t␘ r␘ callback value t␘ callback win_beh
-    new 2                   ; t␘ r␘ callback value rcb
+    new 2                   ; t␘ r␘ callback value rcb=win_beh.(callback t␘)
     pick 4                  ; t␘ r␘ callback value rcb r␘
     pair 2                  ; t␘ r␘ callback rreq=(r␘ rcb . value)
     state 1                 ; t␘ r␘ callback rreq requestor
@@ -61,7 +61,7 @@ race:
     pick 4                  ; t␘ r␘ callback result time_limit r␘
     pick 4                  ; t␘ r␘ callback result time_limit r␘ callback
     push win_beh            ; t␘ r␘ callback result time_limit r␘ callback win_beh
-    new 2                   ; t␘ r␘ callback result time_limit tcb
+    new 2                   ; t␘ r␘ callback result time_limit tcb=win_beh.(callback r␘)
     pick 6                  ; t␘ r␘ callback result time_limit tcb t␘
     pair 3                  ; t␘ r␘ callback treq=(t␘ tcb time_limit . result)
     state 3                 ; t␘ r␘ callback treq timer_dev
@@ -74,7 +74,7 @@ cancel_all_beh:             ; cancellers <- reason
     msg 0                   ; cancellers #nil reason
     pair 1                  ; cancellers (reason)
     push lib.broadcast_beh  ; cancellers (reason) broadcast_beh
-    new 1                   ; cancellers broadcast
+    new 1                   ; cancellers broadcast=broadcast_beh.((reason))
     send -1                 ; --
     push std.sink_beh       ; sink_beh
     beh -1                  ; --
@@ -98,7 +98,7 @@ boot:                       ; () <- {caps}
     push 10000              ; {caps} time_limit delay=10000
     push 111                ; {caps} time_limit delay value=111
     push test_beh           ; {caps} time_limit delay value test_beh
-    new 3                   ; {caps} test
+    new 3                   ; {caps} test=test_beh.(value delay time_limit)
     send -1                 ; --
 
 ; Scenario 2: the requestor succeeds within the time limit.
@@ -108,7 +108,7 @@ boot:                       ; () <- {caps}
     push 7500               ; {caps} time_limit delay=7500
     push 222                ; {caps} time_limit delay value=222
     push test_beh           ; {caps} time_limit delay value test_beh
-    new 3                   ; {caps} test
+    new 3                   ; {caps} test=test_beh.(value delay time_limit)
     send -1                 ; --
 
 ; Scenario 3: the operation is cancelled early. There should be no output.
@@ -119,7 +119,7 @@ boot:                       ; () <- {caps}
     push 5000               ; {caps} cancel_ms time_limit delay=5000
     push 333                ; {caps} cancel_ms time_limit delay value=333
     push test_beh           ; {caps} cancel_ms time_limit delay value test_beh
-    new 4                   ; {caps} test
+    new 4                   ; {caps} test=test_beh.(value delay time_limit cancel_ms)
     send -1                 ; --
 
 ; Scenario 4: the operation is cancelled after the requestor succeeds.
@@ -130,7 +130,7 @@ boot:                       ; () <- {caps}
     push 10000              ; {caps} cancel_ms time_limit delay=10000
     push 444                ; {caps} cancel_ms time_limit delay value=444
     push test_beh           ; {caps} cancel_ms time_limit delay value test_beh
-    new 4                   ; {caps} test
+    new 4                   ; {caps} test=test_beh.(value delay time_limit cancel_ms)
     send -1                 ; --
 
 ; The debug device's output, in order, should resemble:
@@ -153,16 +153,16 @@ test_beh:                   ; (value delay_ms time_limit cancel_ms) <- {caps}
     dup 1                   ; timer_dev timer_dev
     state 2                 ; timer_dev timer_dev delay_ms
     push thru.beh           ; timer_dev timer_dev delay_ms thru_beh
-    new 0                   ; timer_dev timer_dev delay_ms thru
+    new 0                   ; timer_dev timer_dev delay_ms thru=thru_beh.()
     push delay.beh          ; timer_dev timer_dev delay_ms thru delay_beh
-    new 3                   ; timer_dev delay
+    new 3                   ; timer_dev delay=delay_beh.(thru delay_ms timer_dev)
     roll 2                  ; delay timer_dev
     state 3                 ; delay timer_dev time_limit
     roll 3                  ; timer_dev time_limit delay
     push timeout_beh        ; timer_dev time_limit delay timeout_beh
-    new 3                   ; timeout
+    new 3                   ; timeout=timeout_beh.(delay time_limit timer_dev)
     push canceller.beh      ; timeout canceller_beh
-    new 0                   ; timeout canceller
+    new 0                   ; timeout canceller=canceller_beh.()
     state 1                 ; timeout canceller value
     msg 0                   ; timeout canceller value {caps}
     push dev.debug_key      ; timeout canceller value {caps} debug_key

--- a/ufork-wasm/src/core.rs
+++ b/ufork-wasm/src/core.rs
@@ -620,7 +620,7 @@ pub const RAM_TOP_OFS: usize = RAM_BASE_OFS;
             },
             VM_IF => {
                 let b = self.stack_pop();
-                if falsey(b) { kip } else { imm }
+                if falsy(b) { kip } else { imm }
             },
             VM_MSG => {
                 let n = imm.get_fix()?;
@@ -1971,7 +1971,7 @@ fn u16_msb(nat: usize) -> u8 {
     ((nat >> 8) & 0xFF) as u8
 }
 
-fn falsey(v: Any) -> bool {
+fn falsy(v: Any) -> bool {
     v == FALSE || v == UNDEF || v == NIL || v == ZERO
 }
 

--- a/ufork-wasm/src/core.rs
+++ b/ufork-wasm/src/core.rs
@@ -15,7 +15,7 @@ pub const IO_DEV: Any       = Any { raw: OPQ_RAW | MUT_RAW | 4 };
 pub const BLOB_DEV: Any     = Any { raw: OPQ_RAW | MUT_RAW | 5 };
 pub const TIMER_DEV: Any    = Any { raw: OPQ_RAW | MUT_RAW | 6 };
 pub const MEMO_DEV: Any     = Any { raw: OPQ_RAW | MUT_RAW | 7 };
-pub const AWP_DEV: Any      = Any { raw: OPQ_RAW | MUT_RAW | 8 };
+pub const HOST_DEV: Any     = Any { raw: OPQ_RAW | MUT_RAW | 8 };
 pub const SPONSOR: Any      = Any { raw: MUT_RAW | 15 };
 
 pub const RAM_BASE_OFS: usize = 16;  // RAM offsets below this value are reserved
@@ -94,7 +94,7 @@ pub const ROM_TOP_OFS: usize = ROM_BASE_OFS;
         quad_ram[BLOB_DEV.ofs()]    = Quad::actor_t(PLUS_3, NIL, UNDEF);  // blob device #3
         quad_ram[TIMER_DEV.ofs()]   = Quad::actor_t(PLUS_4, NIL, UNDEF);  // timer device #4
         quad_ram[MEMO_DEV.ofs()]    = Quad::actor_t(PLUS_5, NIL, UNDEF);  // memo device #5
-        quad_ram[AWP_DEV.ofs()]     = Quad::actor_t(PLUS_6, NIL, UNDEF);  // AWP device #6
+        quad_ram[HOST_DEV.ofs()]    = Quad::actor_t(PLUS_6, NIL, UNDEF);  // host device #6
         quad_ram[SPONSOR.ofs()]     = Quad::sponsor_t(
                                     Any::fix(512),
                                     Any::fix(64),
@@ -153,7 +153,7 @@ pub const RAM_TOP_OFS: usize = RAM_BASE_OFS;
                 Some(Box::new(BlobDevice::new())),
                 Some(Box::new(TimerDevice::new())),
                 Some(Box::new(NullDevice::new())),
-                Some(Box::new(AwpDevice::new())),
+                Some(Box::new(HostDevice::new())),
             ],
             rom_top: Any::rom(ROM_TOP_OFS),
             gc_state: UNDEF,

--- a/ufork-wasm/src/device.rs
+++ b/ufork-wasm/src/device.rs
@@ -549,34 +549,34 @@ impl Device for TimerDevice {
     }
 }
 
-pub struct AwpDevice {}
-impl AwpDevice {
-    pub fn new() -> AwpDevice {
-        AwpDevice {}
+pub struct HostDevice {}
+impl HostDevice {
+    pub fn new() -> HostDevice {
+        HostDevice {}
     }
     #[cfg(target_arch = "wasm32")]
-    fn forward_event(&mut self, event_stub_or_proxy: Any) -> Error {
+    fn to_host(&mut self, event_stub_or_proxy: Any) -> Error {
         unsafe {
-            crate::host_awp(event_stub_or_proxy.raw())
+            crate::host(event_stub_or_proxy.raw())
         }
     }
     #[cfg(not(target_arch = "wasm32"))]
-    fn forward_event(&mut self, _event_stub_or_proxy: Any) -> Error {
-        // AWP device not available...
+    fn to_host(&mut self, _event_stub_or_proxy: Any) -> Error {
+        // host device not available...
         E_OK
     }
 }
-impl Device for AwpDevice {
+impl Device for HostDevice {
     fn handle_event(&mut self, core: &mut Core, ep: Any) -> Result<(), Error> {
         let event = core.mem(ep);
         let device = event.x();
         let event_stub = core.reserve_stub(device, ep)?;
-        match self.forward_event(event_stub) {
+        match self.to_host(event_stub) {
             E_OK => Ok(()),
-            code => Err(code)
+            code => Err(code) // TODO release the stub here
         }
     }
     fn drop_proxy(&mut self, _core: &mut Core, proxy: Any) {
-        self.forward_event(proxy);
+        self.to_host(proxy);
     }
 }

--- a/ufork-wasm/src/lib.rs
+++ b/ufork-wasm/src/lib.rs
@@ -73,8 +73,8 @@ extern {
     pub fn host_stop_timer(stub: Raw) -> bool;
     pub fn host_write(code: Raw) -> Raw;
     pub fn host_read(stub: Raw) -> Raw;
-    pub fn host_awp(event_stub: Raw) -> Error;
     pub fn host_trace(event: Raw);
+    pub fn host(event_stub_or_proxy: Raw) -> Error;
 }
 
 // trace transactional effect(s)

--- a/ufork-wasm/vm.md
+++ b/ufork-wasm/vm.md
@@ -129,7 +129,7 @@ _n_ _m_           | {x:VM_cmp, y:GT, z:_K_}         | _bool_   | `TRUE` if _n_ >
 _n_ _m_           | {x:VM_cmp, y:LT, z:_K_}         | _bool_   | `TRUE` if _n_ < _m_, otherwise `FALSE`
 _n_ _m_           | {x:VM_cmp, y:LE, z:_K_}         | _bool_   | `TRUE` if _n_ <= _m_, otherwise `FALSE`
 _n_ _m_           | {x:VM_cmp, y:NE, z:_K_}         | _bool_   | `TRUE` if _n_ != _m_, otherwise `FALSE`
-_bool_            | {x:VM_if, y:_T_, z:_F_}         | —        | continue _F_ if "falsey", otherwise continue _T_
+_bool_            | {x:VM_if, y:_T_, z:_F_}         | —        | continue _F_ if "falsy", otherwise continue _T_
 —                 | {x:VM_msg, y:0, z:_K_}          | _msg_    | copy event message to stack
 —                 | {x:VM_msg, y:_n_, z:_K_}        | _msgₙ_   | copy message item _n_ to stack
 —                 | {x:VM_msg, y:-_n_, z:_K_}       | _tailₙ_  | copy message tail _n_ to stack

--- a/ufork-wasm/www/devices/awp_device.js
+++ b/ufork-wasm/www/devices/awp_device.js
@@ -6,7 +6,7 @@
 
 // TODO:
 // - distributed garbage collection
-// - swiss interning
+// - acquaintance interning
 // - cancel/stop capabilities
 
 /*jslint browser, null, devel, long */

--- a/ufork-wasm/www/devices/awp_device.js
+++ b/ufork-wasm/www/devices/awp_device.js
@@ -275,7 +275,7 @@ function awp_device(
 
 // (cancel_customer greeting_callback petname . hello) -> greeter
 
-            const evt = core.h_reserve_ram({
+            core.h_event_enqueue(core.h_reserve_ram({
                 t: sponsor,
                 x: greeter,
                 y: core.h_reserve_ram({
@@ -291,8 +291,7 @@ function awp_device(
                         })
                     })
                 })
-            });
-            core.h_event_enqueue(evt);
+            }));
             return resume();
         }
 
@@ -300,12 +299,11 @@ function awp_device(
 
         const stub = stubs[hex.encode(frame.target)];
         if (stub !== undefined) {
-            const evt = core.h_reserve_ram({
+            core.h_event_enqueue(core.h_reserve_ram({
                 t: sponsor,
                 x: core.u_read_quad(stub).y,
                 y: unmarshall(store, frame.message)
-            });
-            core.h_event_enqueue(evt);
+            }));
             return resume();
         }
         if (core.u_warn !== undefined) {
@@ -530,7 +528,7 @@ function awp_device(
                 if (core.u_debug !== undefined) {
                     core.u_debug("intro fail");
                 }
-                const evt = core.h_reserve_ram({
+                core.h_event_enqueue(core.h_reserve_ram({
                     t: sponsor,
                     x: callback_fwd,
                     y: core.h_reserve_ram({
@@ -538,8 +536,7 @@ function awp_device(
                         x: ufork.UNDEF_RAW,
                         y: core.u_fixnum(-1) // TODO error codes
                     })
-                });
-                core.h_event_enqueue(evt);
+                }));
 
 // We could release the callback's stub here, but it becomes a sink once it
 // forwards the reply so we can safely leave it for the distributed GC to clean
@@ -585,12 +582,11 @@ function awp_device(
 
 // (stop . reason) -> listen_callback
 
-            const evt = core.h_reserve_ram({
+            core.h_event_enqueue(core.h_reserve_ram({
                 t: sponsor,
                 x: listen_callback,
                 y: reply
-            });
-            core.h_event_enqueue(evt);
+            }));
             release_event_stub();
             return resume();
         }

--- a/ufork-wasm/www/devices/awp_device.js
+++ b/ufork-wasm/www/devices/awp_device.js
@@ -16,6 +16,8 @@ import OED from "../oed.js";
 import hex from "../hex.js";
 import dummy_transport from "../transports/dummy_transport.js";
 
+const awp_key = 100; // from dev.asm
+
 function stringify(value) {
 
 // Returns a string representation of an OED-encodable value.
@@ -25,13 +27,14 @@ function stringify(value) {
 
 function awp_device(
     core,
+    make_dynamic_device,
     transport = dummy_transport(),
     stores = [],
     webcrypto = crypto // Node.js does not have a 'crypto' global
 ) {
     const sponsor = core.u_ramptr(ufork.SPONSOR_OFS);
-    const device = core.u_ptr_to_cap(core.u_ramptr(ufork.AWP_DEV_OFS));
 
+    let dynamic_device;
     let connections = Object.create(null);  // local:remote -> connection object
     let opening = Object.create(null);      // local:remote -> cancel function
     let outbox = Object.create(null);       // local:remote -> messages
@@ -60,11 +63,7 @@ function awp_device(
         }
         const handle = handle_to_proxy_key.length;
         handle_to_proxy_key.push(proxy_key);
-        const raw = core.u_ptr_to_cap(core.h_reserve_ram({
-            t: ufork.PROXY_T,
-            x: device,
-            y: core.u_fixnum(handle)
-        }));
+        const raw = dynamic_device.h_reserve_proxy(core.u_fixnum(handle));
         proxies[proxy_key] = {raw, swiss, store, petname};
         return raw;
     }
@@ -152,7 +151,7 @@ function awp_device(
                         swiss = random_swiss();
                         stubs[
                             hex.encode(swiss)
-                        ] = core.h_reserve_stub(device, raw);
+                        ] = dynamic_device.h_reserve_stub(raw);
                         raw_to_swiss[raw] = swiss;
                     }
                     return {
@@ -161,7 +160,11 @@ function awp_device(
                     };
                 }
                 if (quad.t === ufork.PROXY_T) {
-                    const handle = core.u_fix_to_i32(quad.y);
+
+// Strip the dynamic device metadata from the proxy's handle.
+
+                    const handle_raw = core.u_nth(quad.y, -1);
+                    const handle = core.u_fix_to_i32(handle_raw);
                     const proxy = proxies[handle_to_proxy_key[handle]];
                     const acquaintance = proxy.store.acquaintances[
                         proxy.petname
@@ -239,7 +242,7 @@ function awp_device(
     }
 
     function resume() {
-        core.h_wakeup(ufork.AWP_DEV_OFS);
+        core.h_wakeup(ufork.HOST_DEV_OFS);
     }
 
     function unregister(key) {
@@ -646,7 +649,7 @@ function awp_device(
                             y: core.u_fixnum(-1) // TODO error codes
                         }));
                     }
-                    greeters[key] = core.h_reserve_stub(device, greeter);
+                    greeters[key] = dynamic_device.h_reserve_stub(greeter);
 
                     function safe_stop() {
                         if (greeters[key] !== undefined) {
@@ -690,76 +693,68 @@ function awp_device(
         return ufork.E_OK;
     }
 
-    function handle_event(event_stub_ptr) {
+// Install the device.
+
+    dynamic_device = make_dynamic_device(
+        function on_event_stub(event_stub_ptr) {
 
 // The event stub retains the event, including its message, in memory until
 // explicitly released. This is necessary because h_reserve_stub is
 // non-reentrant, so marshalling must take place on a future turn and we don't
 // want the message to be GC'd in the meantime.
 
-        const event_stub = core.u_read_quad(event_stub_ptr);
-        const event = core.u_read_quad(event_stub.y);
-        const message = event.y;
+            const event_stub = core.u_read_quad(event_stub_ptr);
+            const event = core.u_read_quad(event_stub.y);
+            const message = event.y;
 
 // Inspect the event target. If it is a proxy, forward the message to a remote
-// actor.
+// actor, stripping the dynamic device metadata from the handle.
 
-        const target_quad = core.u_read_quad(core.u_cap_to_ptr(event.x));
-        if (target_quad.t === ufork.PROXY_T) {
-            const handle = core.u_fix_to_i32(target_quad.y);
-            return forward(event_stub_ptr, handle, message);
-        }
+            const target_quad = core.u_read_quad(core.u_cap_to_ptr(event.x));
+            if (target_quad.t === ufork.PROXY_T) {
+                const handle_raw = core.u_nth(target_quad.y, -1);
+                const handle = core.u_fix_to_i32(handle_raw);
+                return forward(event_stub_ptr, handle, message);
+            }
 
-// Choose a method based on the message tag (#intro, #listen, etc).
+// Choose a method based on the message tag (#intro, #listen, etc). Note that
+// the message is tagged with dynamic device metadata, so we skip the head of
+// the list.
 
-        const tag = core.u_nth(message, 1);
-        if (!core.u_is_fix(tag)) {
-            return ufork.E_FAIL;
-        }
-        const method_array = [intro, listen];
-        const method = method_array[core.u_fix_to_i32(tag)];
-        if (method === undefined) {
-            return ufork.E_BOUNDS;
-        }
+            const tag = core.u_nth(message, 2);
+            if (!core.u_is_fix(tag)) {
+                return ufork.E_FAIL;
+            }
+            const method_array = [intro, listen];
+            const method = method_array[core.u_fix_to_i32(tag)];
+            if (method === undefined) {
+                return ufork.E_BOUNDS;
+            }
 
 // Forward the remainder of the message to the chosen method. The method may
 // need to reserve stubs for the portions of the message it will need later.
 // When the method is done doing that, it should release the event stub.
 
-        return method(event_stub_ptr, core.u_nth(message, -1));
-    }
-
-    function release_proxy(proxy_raw) {
+            return method(event_stub_ptr, core.u_nth(message, -2));
+        },
+        function on_drop_proxy(handle_raw) {
 
 // A proxy has been garbage collected.
 
-        const quad = core.u_read_quad(core.u_cap_to_ptr(proxy_raw));
-        const handle = core.u_fix_to_i32(quad.y);
-        delete proxies[handle_to_proxy_key[handle]];
+            const handle = core.u_fix_to_i32(handle_raw);
+            delete proxies[handle_to_proxy_key[handle]];
 
 // TODO inform the relevant party.
 
-        return ufork.E_OK;
-    }
-
-// Install the device.
-
-    core.h_install(
-        [[
-            ufork.AWP_DEV_OFS,
-            core.u_ptr_to_cap(core.u_ramptr(ufork.AWP_DEV_OFS))
-        ]],
-        {
-            host_awp(raw) {
-                return (
-                    core.u_is_cap(raw)
-                    ? release_proxy(raw)
-                    : handle_event(raw)
-                );
-            }
         }
     );
 
+// Install the dynamic device as if it were a real device. Unlike a real device,
+// we must reserve a stub to keep the capability from being released.
+
+    const awp_device_cap = dynamic_device.h_reserve_cap();
+    core.h_install([[awp_key, awp_device_cap]]);
+    dynamic_device.h_reserve_stub(awp_device_cap);
     return function dispose() {
         Object.values(connections).forEach(function (connection) {
             connection.close();
@@ -767,12 +762,14 @@ function awp_device(
         stops.forEach(function (stop_listening) {
             stop_listening();
         });
+        dynamic_device.dispose();
     };
 }
 
 //debug import parseq from "../parseq.js";
 //debug import lazy from "../requestors/lazy.js";
 //debug import requestorize from "../requestors/requestorize.js";
+//debug import host_device from "./host_device.js";
 //debug const wasm_url = import.meta.resolve(
 //debug     "../../target/wasm32-unknown-unknown/debug/ufork_wasm.wasm"
 //debug );
@@ -851,7 +848,14 @@ function awp_device(
 //debug                     acquaintances: [dana, bob, carol]
 //debug                 }
 //debug             ];
-//debug             dispose = awp_device(core, transport, store, webcrypto);
+//debug             const make_dynamic_device = host_device(core);
+//debug             dispose = awp_device(
+//debug                 core,
+//debug                 make_dynamic_device,
+//debug                 transport,
+//debug                 store,
+//debug                 webcrypto
+//debug             );
 //debug             core.h_boot(asm_module.boot);
 //debug             console.log("IDLE:", core.u_fault_msg(core.h_run_loop()));
 //debug             return true;

--- a/ufork-wasm/www/devices/host_device.js
+++ b/ufork-wasm/www/devices/host_device.js
@@ -1,0 +1,238 @@
+// Installs the host device, making it possible to provide "dynamic" devices
+// without modifying uFork's Rust code.
+
+/*jslint browser */
+
+import assemble from "../assemble.js";
+import ufork from "../ufork.js";
+
+const fwd_to_host_crlf = assemble(`
+beh:                    ; (host_device . key) <- message
+    msg 0               ; message
+    state -1            ; message key
+    pair 1              ; (key . message)
+    state 1             ; (key . message) host_device
+    send -1             ; --
+    end commit
+
+.export
+    beh
+`);
+
+function host_device(core) {
+    let next_key = 0;
+    let dynamic_devices = Object.create(null);
+
+    function handle_event(event_stub_ptr) {
+
+// Route the event stub to the relevant dynamic device.
+
+        const event_stub = core.u_read_quad(event_stub_ptr);
+        const event = core.u_read_quad(event_stub.y);
+        const target_quad = core.u_read_quad(core.u_cap_to_ptr(event.x));
+        const key = (
+            target_quad.t === ufork.PROXY_T
+            ? core.u_nth(target_quad.y, 1)  // handle tag
+            : core.u_nth(event.y, 1)        // message tag
+        );
+        if (!core.u_is_fix(key)) {
+            return ufork.E_NOT_FIX;
+        }
+        const dynamic_device = dynamic_devices[core.u_fix_to_i32(key)];
+        if (dynamic_device === undefined) {
+            return ufork.E_BOUNDS;
+        }
+        return dynamic_device.on_event_stub(event_stub_ptr);
+    }
+
+    function drop_proxy(proxy_raw) {
+
+// A proxy has been garbage collected. Route its handle to the relevant dynamic
+// device.
+
+        const quad = core.u_read_quad(core.u_cap_to_ptr(proxy_raw));
+        const handle = quad.y;
+        const key = core.u_nth(handle, 1);
+        const subhandle = core.u_nth(handle, -1);
+        if (core.u_is_fix(key)) {
+            const dynamic_device = dynamic_devices[core.u_fix_to_i32(key)];
+            if (typeof dynamic_device?.on_drop_proxy === "function") {
+                dynamic_device.on_drop_proxy(subhandle);
+            }
+        }
+    }
+
+// Install the host device.
+
+    const host_device_cap = core.u_ptr_to_cap(
+        core.u_ramptr(ufork.HOST_DEV_OFS)
+    );
+    core.h_install(
+        [[ufork.HOST_DEV_OFS, host_device_cap]],
+        {
+            host(raw) {
+                return (
+                    core.u_is_cap(raw)
+                    ? drop_proxy(raw)
+                    : handle_event(raw)
+                );
+            }
+        }
+    );
+    const fwd_to_host_beh = core.h_load(fwd_to_host_crlf).beh;
+
+    return function make_dynamic_device(
+
+// The 'on_event_stub' parameter is a function that is called when the dynamic
+// device receives a message event via the host device. It returns an integer
+// error code, such as E_OK or E_FAIL.
+
+// There are some subtle differences between events received by a dynamic device
+// and events received by a real device, because some fields are tagged with
+// dynamic device metadata that should be ignored.
+
+// If the event's target is a proxy, then the proxy's handle is a pair like
+// (meta . handle) where the 'handle' is the value provided to
+// dynamic_device.h_reserve_proxy.
+
+// If the event's target is the host device, it was forwarded there by a dynamic
+// device capability produced by dynamic_device.h_reserve_cap. The message
+// field of the event is a pair like (meta . message) where the 'message' is
+// the message sent to the dynamic device capability.
+
+        on_event_stub,
+
+// The 'on_drop_proxy' parameter is a function that is called when a proxy made
+// by 'reserve_proxy' is dropped. It is passed the same handle that was passed
+// to 'reserve_proxy'. Optional.
+
+        on_drop_proxy
+    ) {
+        const key = next_key;
+        next_key += 1;
+        dynamic_devices[key] = {on_event_stub, on_drop_proxy};
+
+        function h_reserve_cap() {
+
+// Make a capability for the dynamic device. It forwards each message it
+// receives to the host device, first tagging it with the dynamic device's key.
+
+// Unlike real device capabilities, this capability is vulnerable to garbage
+// collection.
+
+            return core.u_ptr_to_cap(core.h_reserve_ram({
+                t: ufork.ACTOR_T,
+                x: fwd_to_host_beh,
+                y: core.h_reserve_ram({
+                    t: ufork.PAIR_T,
+                    x: host_device_cap,
+                    y: core.u_fixnum(key)
+                })
+            }));
+        }
+
+        function h_reserve_proxy(handle_raw) {
+
+// Makes a proxy whose handle is tagged with the dynamic device's key.
+
+            return core.u_ptr_to_cap(core.h_reserve_ram({
+                t: ufork.PROXY_T,
+                x: host_device_cap,
+                y: core.h_reserve_ram({
+                    t: ufork.PAIR_T,
+                    x: core.u_fixnum(key),
+                    y: handle_raw
+                })
+            }));
+        }
+
+        function h_reserve_stub(target_raw) {
+            return core.h_reserve_stub(host_device_cap, target_raw);
+        }
+
+        function dispose() {
+            delete dynamic_devices[key];
+        }
+
+        return Object.freeze({
+            h_reserve_cap,
+            h_reserve_stub,
+            h_reserve_proxy,
+            dispose
+        });
+    };
+}
+
+//debug import parseq from "../parseq.js";
+//debug import lazy from "../requestors/lazy.js";
+//debug import requestorize from "../requestors/requestorize.js";
+//debug const wasm_url = import.meta.resolve(
+//debug     "../../target/wasm32-unknown-unknown/debug/ufork_wasm.wasm"
+//debug );
+//debug let dispose;
+//debug let core;
+//debug function dummy_device(make_dynamic_device) {
+//debug     const dynamic_device = make_dynamic_device(
+//debug         function on_event_stub(ptr) {
+//debug             const event_stub = core.u_read_quad(ptr);
+//debug             const target = core.u_read_quad(
+//debug                 core.u_cap_to_ptr(event_stub.x)
+//debug             );
+//debug             const event = core.u_read_quad(event_stub.y);
+//debug             if (target.t === ufork.PROXY_T) {
+//debug                 console.log(
+//debug                     "on_event_stub proxy",
+//debug                     core.u_pprint(event.y), // message
+//debug                     core.u_pprint(core.u_nth(target.y, -1)) // handle
+//debug                 );
+//debug             } else {
+//debug                 console.log(
+//debug                     "on_event_stub message",
+//debug                     core.u_pprint(core.u_nth(event.y, -1))
+//debug                 );
+//debug             }
+//debug         },
+//debug         function on_drop_proxy(handle) {
+//debug             console.log("on_drop_proxy", core.u_pprint(handle));
+//debug         }
+//debug     );
+//debug     dynamic_device.h_reserve_proxy(ufork.FALSE_RAW); // dropped
+//debug     let proxy = dynamic_device.h_reserve_proxy(ufork.TRUE_RAW);
+//debug     let dummy_cap = dynamic_device.h_reserve_cap();
+//debug     let dummy_cap_stub = dynamic_device.h_reserve_stub(dummy_cap);
+//debug     core.h_install([[1000, dummy_cap]]);
+//debug     core.h_install([[1001, proxy]]);
+//debug     return function dispose() {
+//debug         dynamic_device.dispose();
+//debug         if (dummy_cap_stub !== undefined) {
+//debug             core.h_release_stub(dummy_cap_stub);
+//debug             dummy_cap_stub = undefined;
+//debug         }
+//debug     };
+//debug }
+//debug parseq.sequence([
+//debug     ufork.instantiate_core(
+//debug         wasm_url,
+//debug         function on_wakeup() {
+//debug             console.log("IDLE:", core.u_fault_msg(core.h_run_loop()));
+//debug         },
+//debug         console.log,
+//debug         ufork.LOG_DEBUG
+//debug     ),
+//debug     lazy(function (the_core) {
+//debug         core = the_core;
+//debug         return core.h_import(import.meta.resolve(
+//debug             "../../lib/host_device.asm"
+//debug         ));
+//debug     }),
+//debug     requestorize(function (asm_module) {
+//debug         dispose = dummy_device(host_device(core));
+//debug         core.h_boot(asm_module.boot);
+//debug         return core.u_fault_msg(core.h_run_loop());
+//debug     })
+//debug ])(console.log);
+//debug setTimeout(function () {
+//debug     dispose();
+//debug }, 1000);
+
+export default Object.freeze(host_device);

--- a/ufork-wasm/www/devices/io_device.js
+++ b/ufork-wasm/www/devices/io_device.js
@@ -17,7 +17,7 @@ function io_device(core, on_stdout) {
             return core.UNDEF_RAW;
         }
         const first = stdin_buffer[0];
-        stdin_buffer = stdin_buffer.slice(1);  // FIXME: handle codepoints > 0xFFFF
+        stdin_buffer = stdin_buffer.slice(1);
         const code = first.codePointAt(0);
         const char = core.u_fixnum(code);  // character read
         return char;
@@ -81,7 +81,7 @@ function io_device(core, on_stdout) {
             },
             host_read(stub) { // (i32) -> i32
                 const char = read_stdin();
-                if (char == core.UNDEF_RAW) {
+                if (char === core.UNDEF_RAW) {
                     listen_stdin(stub);
                 }
                 return char;

--- a/ufork-wasm/www/index.js
+++ b/ufork-wasm/www/index.js
@@ -548,7 +548,6 @@ ufork.instantiate_core(
     on_stdin = io_device(core, on_stdout);
     blob_device(core);
     timer_device(core);
-    awp_device(core);
 
     // draw initial state
     update_rom_monitor();

--- a/ufork-wasm/www/ufork.js
+++ b/ufork-wasm/www/ufork.js
@@ -1158,7 +1158,7 @@ function make_core(
         return u_print(raw);
     }
 
-    function h_boot(instr_ptr) {
+    function h_boot(instr_ptr, state_ptr = NIL_RAW) {
         if (instr_ptr === undefined || !u_is_ptr(instr_ptr)) {
             throw new Error("Not an instruction: " + u_pprint(instr_ptr));
         }
@@ -1168,7 +1168,7 @@ function make_core(
         const actor = h_reserve_ram({
             t: ACTOR_T,
             x: instr_ptr,
-            y: NIL_RAW,
+            y: state_ptr,
             z: UNDEF_RAW
         });
 

--- a/ufork-wasm/www/ufork.js
+++ b/ufork-wasm/www/ufork.js
@@ -123,7 +123,7 @@ const IO_DEV_OFS = 4;
 const BLOB_DEV_OFS = 5;
 const TIMER_DEV_OFS = 6;
 const MEMO_DEV_OFS = 7;
-const AWP_DEV_OFS = 8;
+const HOST_DEV_OFS = 8;
 const SPONSOR_OFS = 15;
 
 // Error codes (from core.rs)
@@ -1420,11 +1420,11 @@ function instantiate_core(
                         host_write(...args) {
                             return mutable_wasm_caps.host_write(...args);
                         },
-                        host_awp(...args) {
-                            return mutable_wasm_caps.host_awp(...args);
-                        },
                         host_trace(...args) {
                             return mutable_wasm_caps.host_trace(...args);
+                        },
+                        host(...args) {
+                            return mutable_wasm_caps.host(...args);
                         }
                     }
                 }
@@ -1559,7 +1559,7 @@ export default Object.freeze({
     BLOB_DEV_OFS,
     TIMER_DEV_OFS,
     MEMO_DEV_OFS,
-    AWP_DEV_OFS,
+    HOST_DEV_OFS,
     SPONSOR_OFS,
     E_OK,
     E_FAIL,

--- a/ufork-wasm/www/ufork.js
+++ b/ufork-wasm/www/ufork.js
@@ -21,18 +21,18 @@
 //      An integer controlling the core's logging verbosity. Each level includes
 //      all levels before it.
 
-//      ufork.LOG_NONE = 0
+//      ufork.LOG_NONE (0)
 //          No logging.
-//      ufork.LOG_INFO = 1
+//      ufork.LOG_INFO (1)
 //          Low volume, always shown unless all logging is disabled.
-//      ufork.LOG_WARN = 2
+//      ufork.LOG_WARN (2)
 //          Something went wrong, but perhaps it wasn't fatal.
-//      ufork.LOG_DEBUG = 3
+//      ufork.LOG_DEBUG (3)
 //          More detail to narrow down the source of a problem.
-//      ufork.LOG_TRACE = 4
+//      ufork.LOG_TRACE (4)
 //          Extremely detailed (for example, all reserve and release actions).
 
-//      The default value is LOG_WARN.
+//      The default level is LOG_WARN.
 
 // The returned requestor produces a core object containing a bunch of methods.
 // The methods beginning with "u_" are reentrant, but the methods beginning


### PR DESCRIPTION
The PR introduces the "host" device, which can be used to register multiple "dynamic" devices that are happy to take an event stub and not re-enter. To prove it works, the AWP device has been turned into a dynamic device.

The impetus for this change was the need to provide a "verdict" capability to the test entry point of assembly modules. This can now be achieved by making a dynamic "verdict" device, and device.rs does not need to be changed.