### PR TITLE
Add optimizations for release build

### DIFF
--- a/ufork-wasm/.cargo/config.toml
+++ b/ufork-wasm/.cargo/config.toml
@@ -1,3 +1,12 @@
 [build]
 target = "wasm32-unknown-unknown"
-target-dir = "./target"
+
+[profile.dev]
+panic = "abort"					# abort on panic!()
+
+[profile.release]
+panic = "abort"					# abort on panic!()
+opt-level = "z"					# optimize for small code size
+lto = true              		# enable link time optimization
+strip = true            		# strip debug symbols
+codegen-units = 1               # use a single codegen-unit for better optimizations

--- a/ufork-wasm/.gitignore
+++ b/ufork-wasm/.gitignore
@@ -1,2 +1,3 @@
 package-lock.json
 target
+www/wasm/*.wasm

--- a/ufork-wasm/Cargo.toml
+++ b/ufork-wasm/Cargo.toml
@@ -7,15 +7,6 @@ description = "uFork VM in Rust targeting WASM"
 repository = "https://github.com/organix/uFork/tree/main/ufork-wasm"
 license = "Apache-2.0"
 
-[profile.dev]
-panic = "abort"					# abort on panic!()
-
-[profile.release]
-panic = "abort"					# abort on panic!()
-opt-level = "s"					# optimize for small code size
-lto = true              		# enable link time optimization
-strip = true            		# strip debug symbols
-
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/ufork-wasm/build.sh
+++ b/ufork-wasm/build.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+pushd "$( dirname "${BASH_SOURCE[0]}" )"
+
 rustup default stable \
 && rustup target add wasm32-unknown-unknown \
 && cargo build \
 && cargo build --release \
-&& du -h ./target/*/*/*.wasm
+&& cp ./target/wasm32-unknown-unknown/debug/ufork_wasm.wasm www/wasm/ufork_wasm.wasm \
+&& cp ./target/wasm32-unknown-unknown/release/ufork_wasm.wasm www/wasm/ufork_wasm.opt.wasm \
+&& du -h www/wasm/*.wasm

--- a/ufork-wasm/build_optimized.sh
+++ b/ufork-wasm/build_optimized.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+pushd "$( dirname "${BASH_SOURCE[0]}" )"
+
+nightly="nightly-2023-10-09"
+
+# RUSTFLAGS="-Zlocation-detail=none" disables location details
+# -Z build-std=core,alloc,panic_abort builds a custom std with only the components needed
+# -Z build-std-features=panic_immediate_abort disables panic format generation and immediately aborts
+
+cargo install wasm-opt \
+&& rustup +"$nightly" target add wasm32-unknown-unknown \
+&& rustup +"$nightly" component add rust-src \
+&& cargo +"$nightly" build --release -Z build-std=core,alloc,panic_abort -Z build-std-features=panic_immediate_abort \
+&& wasm-opt -Oz -o www/wasm/ufork_wasm.opt.wasm target/wasm32-unknown-unknown/release/ufork_wasm.wasm \
+&& du -h www/wasm/ufork_wasm.opt.wasm

--- a/ufork-wasm/examples/grant_matcher/party.js
+++ b/ufork-wasm/examples/grant_matcher/party.js
@@ -29,7 +29,7 @@ function party(asm_url, acquaintance_names = []) {
     const transport = webrtc_transport(websockets_signaller(), print);
     const core = ufork.make_core({
         wasm_url: import.meta.resolve(
-            "../../target/wasm32-unknown-unknown/debug/ufork_wasm.wasm"
+            "../../www/wasm/ufork_wasm.wasm"
         ),
         on_wakeup() {
             const sig = core.h_run_loop(0);

--- a/ufork-wasm/examples/grant_matcher/tls.js
+++ b/ufork-wasm/examples/grant_matcher/tls.js
@@ -67,7 +67,7 @@ const asm_url = new URL(
     origin + "/examples/grant_matcher/"
 ).href;
 const core = ufork.make_core({
-    wasm_url: origin + "/target/wasm32-unknown-unknown/debug/ufork_wasm.wasm",
+    wasm_url: origin + "/www/wasm/ufork_wasm.wasm",
     on_wakeup() {
         console.log(
             "IDLE",

--- a/ufork-wasm/examples/peer_chat/chat.js
+++ b/ufork-wasm/examples/peer_chat/chat.js
@@ -178,7 +178,7 @@ function save_store(store) {
 
 const transport = webrtc_transport(websockets_signaller(), console.log);
 const wasm_url = new URL(
-    "../../target/wasm32-unknown-unknown/release/ufork_wasm.wasm",
+    "../../www/wasm/ufork_wasm.opt.wasm",
     import.meta.url
 ).href;
 const asm_url = new URL("./chat.asm", import.meta.url).href;

--- a/ufork-wasm/examples/stdio/stdio.js
+++ b/ufork-wasm/examples/stdio/stdio.js
@@ -16,7 +16,7 @@ import parseq from "../../www/parseq.js";
 import requestorize from "../../www/requestors/requestorize.js";
 import io_device from "../../www/devices/io_device.js";
 const wasm_url = import.meta.resolve(
-    "../../target/wasm32-unknown-unknown/debug/ufork_wasm.wasm"
+    "../../www/wasm/ufork_wasm.wasm"
 );
 
 const utf8_encoder = new TextEncoder();

--- a/ufork-wasm/serve.sh
+++ b/ufork-wasm/serve.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+pushd "$( dirname "${BASH_SOURCE[0]}" )"
+
 node www/server.js

--- a/ufork-wasm/www/asm_test.js
+++ b/ufork-wasm/www/asm_test.js
@@ -45,7 +45,7 @@ function asm_test(module_url) {
 
     core = ufork.make_core({
         wasm_url: import.meta.resolve(
-            "../target/wasm32-unknown-unknown/debug/ufork_wasm.wasm"
+            "../www/wasm/ufork_wasm.wasm"
         ),
         on_wakeup: run_ufork,
         on_log(...args) {

--- a/ufork-wasm/www/devices/awp_device.js
+++ b/ufork-wasm/www/devices/awp_device.js
@@ -887,7 +887,7 @@ function awp_device({
 //debug import requestorize from "../requestors/requestorize.js";
 //debug import host_device from "./host_device.js";
 //debug const wasm_url = import.meta.resolve(
-//debug     "../../target/wasm32-unknown-unknown/debug/ufork_wasm.wasm"
+//debug     "../../www/wasm/ufork_wasm.wasm"
 //debug );
 //debug const asm_url = import.meta.resolve(
 //debug     "../../lib/grant_matcher.asm"

--- a/ufork-wasm/www/devices/host_device.js
+++ b/ufork-wasm/www/devices/host_device.js
@@ -183,7 +183,7 @@ function host_device(core) {
 //debug import parseq from "../parseq.js";
 //debug import requestorize from "../requestors/requestorize.js";
 //debug const wasm_url = import.meta.resolve(
-//debug     "../../target/wasm32-unknown-unknown/debug/ufork_wasm.wasm"
+//debug     "../../www/wasm/ufork_wasm.wasm"
 //debug );
 //debug let dispose;
 //debug let core;

--- a/ufork-wasm/www/index.js
+++ b/ufork-wasm/www/index.js
@@ -543,7 +543,7 @@ function on_stdout(char) {
 }
 
 core = ufork.make_core({
-    wasm_url: "../target/wasm32-unknown-unknown/debug/ufork_wasm.wasm",
+    wasm_url: "../www/wasm/ufork_wasm.wasm",
     on_wakeup(device_offset) {
         console.log("WAKE:", device_offset);
         //single_step();

--- a/ufork-wasm/www/ufork.js
+++ b/ufork-wasm/www/ufork.js
@@ -1596,7 +1596,7 @@ function make_core({
 //debug }
 //debug core = make_core({
 //debug     wasm_url: import.meta.resolve(
-//debug         "../target/wasm32-unknown-unknown/debug/ufork_wasm.wasm"
+//debug         "../www/wasm/ufork_wasm.wasm"
 //debug     ),
 //debug     on_wakeup(device_offset) {
 //debug         console.log("WAKE:", device_offset);


### PR DESCRIPTION
I switched from bash scripts to [just](https://github.com/casey/just) as a cross-platform task runner, which also unifies how you run things. To install do: `cargo install just`

To build, you can now go into the `ufork-wasm` directory and do `just init` followed by `just all` to build debug and release. `just init` is just needed once tho.

To start the server, you can use `just serve`.

The new binary size for the release wasm is now at ~23k.

I also moved the wasm files into `www/wasm`, to have it in a common location.