### PR TITLE
Add gh action to deploy to pages and run tests

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,62 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  test:
+    uses: ./.github/workflows/tests.yml
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/git
+            ~/.cargo/registry
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build the Rust WASM
+        run: |
+          ./ufork-wasm/build.sh
+          mkdir -p dist
+          cp -r ufork-wasm/www/* dist/
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: './dist'
+
+  deploy:
+    needs: build
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: tests
+on:
+  workflow_call:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/git
+            ~/.cargo/registry
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run tests
+        run: |
+          ./ufork-wasm/test.sh

--- a/ufork-wasm/build.sh
+++ b/ufork-wasm/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 pushd "$( dirname "${BASH_SOURCE[0]}" )"
 
 rustup default stable \

--- a/ufork-wasm/opt_build.sh
+++ b/ufork-wasm/opt_build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 pushd "$( dirname "${BASH_SOURCE[0]}" )"
 
 nightly="nightly-2023-10-09"

--- a/ufork-wasm/test.sh
+++ b/ufork-wasm/test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -euo pipefail
+
+pushd "$( dirname "${BASH_SOURCE[0]}" )"
+
 # Run the test runners in parallel.
 
 deno run \

--- a/ufork-wasm/www/index.html
+++ b/ufork-wasm/www/index.html
@@ -125,6 +125,8 @@ table {
 }
 </style>
 </head>
+<link rel="preload" href="/uFork/ufork_wasm.wasm" as="fetch" type="application/wasm" crossorigin="">
+<link rel="preload" href="/uFork/ufork_wasm.opt.wasm" as="fetch" type="application/wasm" crossorigin="">
 <body>
   <noscript>
     This page contains webassembly and javascript content,


### PR DESCRIPTION
Fixes #58 

To fix the mime-type problem I had to add:
```html
<link rel="preload" href="/uFork/ufork_wasm.wasm" as="fetch" type="application/wasm" crossorigin="">
<link rel="preload" href="/uFork/ufork_wasm.opt.wasm" as="fetch" type="application/wasm" crossorigin="">
```

I added two workflows.
Tests: Run on each merge request and when called from another workflow
Pages: Run on each push on the main branch (should include MR merges)

The pages workflow uses the tests workflow to check if the code is valid.

In the future it might be more reasonable to create proper releases and only deploy when a new release is made. That way the web version had some stability guarantees. But that's not a requirement right now.

@jamesdiacono The deno tests return an object with the fields `pass`, `lost` and `fail`. The only field that's filled on my machine is the `lost` field. If this is a failure, can you make sure to make the test suite return a non-zero exit code? If that's okay, then nothing needs to be done for it to work.