### PR TITLE
Add workflow to publish from tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+on:
+  push:
+    tags:
+      - 'v\d+\.\d+\.\d+'
+  workflow_dispatch:
+
+name: Publish
+
+jobs:
+  test:
+    uses: ./.github/workflows/tests.yml
+
+  publish:
+    name: Publish
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - run: cargo publish --token ${CRATES_TOKEN}
+        working-directory: ./vm/rs
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: tests
+on:
+  workflow_call:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: davidB/rust-cargo-make@v1
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/git
+            ~/.cargo/registry
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run tests
+        run: cargo test
+        working-directory: ./vm/rs


### PR DESCRIPTION
To enable this workflow you need to generate a login token and store that as a secret here in github. You can generate such a token by logging into crates.io and navigating to https://crates.io/me.

The name of the secret must be `CRATES_TOKEN`.

When all of that is done, you can push a tag that matches the version inside the `Cargo.toml`, e.g.: v0.1.0 and the script should automatically start the publishing process.