### PR TITLE
interactive iverilog proof of concept

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -14,7 +14,6 @@ jobs:
 # Build the WASMs and check everything is working.
 
       - uses: denoland/setup-deno@v1
-      - run: deno task build
       - run: deno task test
 
 # Create the web root directory.

--- a/fpga/fomu/echo/Makefile
+++ b/fpga/fomu/echo/Makefile
@@ -1,0 +1,18 @@
+#
+# Makefile
+#
+
+TOP = echo
+
+all: $(TOP).vcd
+
+clean:
+	rm -f *.sim *.vcd
+
+%.sim: %.v
+	iverilog -o $@ $^
+
+%.vcd: %.sim
+	# stty raw # disable line buffering
+	./$<
+	# stty cooked 2>/dev/null || stty cooked # fails the first time??

--- a/fpga/fomu/echo/README.md
+++ b/fpga/fomu/echo/README.md
@@ -1,0 +1,4 @@
+# Simulating I/O
+
+This is a proof of concept showing that a running iverilog simulation can
+receive and transmit characters from the console.

--- a/fpga/fomu/echo/echo.v
+++ b/fpga/fomu/echo/echo.v
@@ -1,0 +1,28 @@
+`default_nettype none
+`timescale 10ns/1ns
+
+module echo;
+    localparam STDIN = 32'h8000_0000;
+    localparam STDOUT = 32'h8000_0001;
+    localparam STDERR = 32'h8000_0002;
+
+    // dump simulation signals
+    initial begin
+        $dumpfile("echo.vcd");
+        $dumpvars(0, echo);
+        #10;
+        $finish;
+    end
+
+    // generate chip clock
+    reg clk = 0;
+    always begin
+        #1 clk = !clk;
+    end
+
+    reg [8:0] char = 0; // 9'b1 indicates error, possibly EOF
+    always @(posedge clk) begin
+        char = $fgetc(STDIN);               // read a char
+        $fwrite(STDOUT, "%c", char[7:0]);   // write a char
+    end
+endmodule

--- a/tools/replete.js
+++ b/tools/replete.js
@@ -14,7 +14,7 @@
 import {toFileUrl} from "https://deno.land/std@0.203.0/path/to_file_url.ts";
 import {fromFileUrl} from "https://deno.land/std@0.203.0/path/from_file_url.ts";
 import ecomcon from "https://raw.githubusercontent.com/douglascrockford/ecomcon/b3eda9196a827666af178199aff1c5b8ad9e45b3/ecomcon.js";
-import run_replete from "https://deno.land/x/replete@0.0.10/run.js";
+import run_replete from "https://deno.land/x/replete@0.0.21/run.js";
 // import {minify} from "https://esm.sh/terser";
 import import_map from "./import_map.js";
 


### PR DESCRIPTION
Seems to work well, except that input is line buffered. This was solved by switching the terminal to raw mode during the simulation (see Makefile) but then newlines show up as `^M`, which I don't understand.