### PR TITLE
LiteX demo project

### DIFF
--- a/fpga/litex/.gitignore
+++ b/fpga/litex/.gitignore
@@ -1,0 +1,2 @@
+litex_pkg
+python_pkg

--- a/fpga/litex/install.sh
+++ b/fpga/litex/install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# Fetch the source code of various LiteX packages.
+
+mkdir litex_pkg
+curl \
+    --remote-name \
+    https://raw.githubusercontent.com/enjoy-digital/litex/master/litex_setup.py
+chmod +x litex_setup.py
+pushd litex_pkg
+../litex_setup.py --init
+rm ../litex_setup.py
+
+# Install each LiteX package using Python's 'pip' installer, confining external
+# Python dependencies to the project directory.
+
+for repo in *
+do
+    pushd "$repo"
+    pip install --upgrade --editable . --target ../../python_pkg
+    popd
+done

--- a/fpga/litex/shell.nix
+++ b/fpga/litex/shell.nix
@@ -1,0 +1,45 @@
+# Running nix-shell from the current directory will drop you into a shell with
+# all the commands necessary to work on this project.
+
+# Download Nix from https://nixos.org/download.html.
+
+# We pin the dependencies to a specific nixpkgs version. They can be upgraded
+# by replacing the hash below with a more recent one obtained from
+# https://status.nixos.org.
+
+{
+    pkgs ? import (
+        fetchTarball
+        "https://github.com/NixOS/nixpkgs/archive/cc54fb41d137.tar.gz"
+    ) {}
+}:
+
+pkgs.mkShell {
+    buildInputs = [
+
+# LiteX prerequisites.
+
+        pkgs.python3                      # https://www.python.org/
+        pkgs.python311Packages.pip        # https://pypi.org/project/pip/
+        pkgs.json_c                       # https://github.com/json-c/json-c/
+        pkgs.libevent                     # https://libevent.org/
+        pkgs.verilator                    # https://www.veripool.org/verilator/
+    ];
+
+    shellHook = ''
+
+# Instead of polluting the "site-packages" directory at the system or user
+# level, use one at the project level.
+
+        PYTHONPATH="$PYTHONPATH:$(pwd)/python_pkg/"
+        export PYTHONPATH
+
+# Take the absence of the Python packages directory to mean installation is
+# required.
+
+        if ! test -d python_pkg
+        then
+            ./install.sh
+        fi
+    '';
+}

--- a/lib/assemble.js
+++ b/lib/assemble.js
@@ -121,7 +121,6 @@ const escape_code_points = {
 function tokenize(text) {
     let rx_token = new RegExp(rx_token_raw, "yu"); // sticky, unicode aware
     let position = 0;
-
     return function token_generator() {
         const coordinates = linecol(text, position);
         const line = coordinates.line + 1;
@@ -388,8 +387,8 @@ function tokenize(text) {
 // This parser is fault-tolerant. It attempts to provide useful information even
 // for invalid source code.
 
-// The parser's source code is heavily inspired, and in places lifted verbatim,
-// from Douglas Crockford's Misty parser, see https://mistysystem.com.
+// The parser's source code is heavily inspired by, and in places lifted
+// verbatim from, Douglas Crockford's Misty parser. See https://mistysystem.com.
 
 const error_bundle = {
     already_a: "{a} was already declared.",


### PR DESCRIPTION
This is as far as I got. Running `nix-shell` from the fpga/litex directory will install additional Nix packages, the standard LiteX packages, and their Python dependencies, without global pollution (that I know of).

Unfortunately, I am getting a ModuleNotFoundError when attempting to run the UP5K script:

```
$ litex_pkg/litex-boards/litex_boards/targets/lattice_ice40up5k_evn.py --help
Traceback (most recent call last):
  File "/Users/me/code/uFork/fpga/litex/litex_pkg/litex-boards/litex_boards/targets/lattice_ice40up5k_evn.py", line 16, in <module>
    from litex_boards.platforms import lattice_ice40up5k_evn
ModuleNotFoundError: No module named 'litex_boards'
```

There is something going wrong with module resolution. The file that should be imported here is `litex_pkg/litex-boards/litex_boards/platforms/lattice_ice40up5k_evn.py`, but even though it is local to the current package (`litex-boards`) it is not found.